### PR TITLE
feat: 셔틀 동작 구현 (XWheel/YWheel 자전, RackAndPinion, Y축 리프트)

### DIFF
--- a/unity/Assets/Scenes/Dev/RealtimeDev.unity
+++ b/unity/Assets/Scenes/Dev/RealtimeDev.unity
@@ -119,6 +119,59 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &45031478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 45031480}
+  - component: {fileID: 45031479}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (base - xwheel2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &45031479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 45031478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 781211674}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.08739436, y: 1.9993577, z: -0.25474867}
+  _lineAPointB: {x: -0.11239433, y: 1.9993577, z: -0.25474867}
+  _lineBPointA: {x: 0.0010631084, y: 1.9993577, z: -0.25474867}
+  _lineBPointB: {x: -0.028936863, y: 1.9993577, z: -0.25474867}
+--- !u!4 &45031480
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 45031478}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.9009585, z: -0.534439}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &203844586
 GameObject:
   m_ObjectHideFlags: 0
@@ -246,6 +299,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 604712594}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &276834149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 276834151}
+  - component: {fileID: 276834150}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (base - xwheel3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &276834150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276834149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 1911020943}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -1.0933518, y: 1.9978918, z: -0.8167308}
+  _lineAPointB: {x: -1.1083944, y: 1.9978918, z: -0.8167308}
+  _lineBPointA: {x: -1.0958519, y: 1.9978918, z: -0.8167308}
+  _lineBPointB: {x: -1.1258519, y: 1.9978918, z: -0.8167308}
+--- !u!4 &276834151
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 276834149}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.9006491, z: -0.5359341}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &316531324
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -254,9 +360,69 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 231727305130331645, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.2028894
+      objectReference: {fileID: 0}
+    - target: {fileID: 231727305130331645, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0313282
+      objectReference: {fileID: 0}
     - target: {fileID: 655791098114694471, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       propertyPath: m_Name
       value: Shuttle
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412932167232329871, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.4790497
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412932167232329871, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.4793644
+      objectReference: {fileID: 0}
+    - target: {fileID: 1764228532557589034, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.6028605
+      objectReference: {fileID: 0}
+    - target: {fileID: 1764228532557589034, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.11867285
+      objectReference: {fileID: 0}
+    - target: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.68315
+      objectReference: {fileID: 0}
+    - target: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.06280005
+      objectReference: {fileID: 0}
+    - target: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.032387435
+      objectReference: {fileID: 0}
+    - target: {fileID: 3223819236138862146, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3223819236138862146, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.32601357
+      objectReference: {fileID: 0}
+    - target: {fileID: 3223819236138862146, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.2378216
+      objectReference: {fileID: 0}
+    - target: {fileID: 3223819236138862146, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4115482821629324989, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.06465614
+      objectReference: {fileID: 0}
+    - target: {fileID: 4115482821629324989, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.03563744
       objectReference: {fileID: 0}
     - target: {fileID: 4724170828665772904, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       propertyPath: m_LocalPosition.x
@@ -298,14 +464,73 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6506328469224593072, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.46937
+      objectReference: {fileID: 0}
+    - target: {fileID: 6506328469224593072, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.7016063
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 4115482821629324989, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      insertIndex: 0
+      addedObject: {fileID: 1911642344}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 655791098114694471, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       insertIndex: -1
       addedObject: {fileID: 868603147}
   m_SourcePrefab: {fileID: 100100000, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+--- !u!1 &417583191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 417583193}
+  - component: {fileID: 417583192}
+  m_Layer: 0
+  m_Name: RevoluteFreezeTestManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &417583192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417583191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 205114c60d9142940910a9e84a757760, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteFreezeTestManager
+  _objectB: {fileID: 1838270707}
+  _jointComponent: {fileID: 684986976}
+  _rotateSpeed: 500
+  _useMouseY: 1
+--- !u!4 &417583193
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417583191}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.2967, y: -0, z: -3.28688}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &505702789
 GameObject:
   m_ObjectHideFlags: 0
@@ -370,6 +595,112 @@ Transform:
   - {fileID: 203844589}
   - {fileID: 2116198339}
   - {fileID: 1182891855}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &647695687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 647695689}
+  - component: {fileID: 647695688}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (base - xwheel4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &647695688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 647695687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 1421536145}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -1.0373944, y: 1.9994061, z: -0.25363746}
+  _lineAPointB: {x: -1.0123944, y: 1.9994061, z: -0.25363746}
+  _lineBPointA: {x: -1.1258519, y: 1.9994061, z: -0.25363746}
+  _lineBPointB: {x: -1.0958519, y: 1.9994061, z: -0.25363746}
+--- !u!4 &647695689
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 647695687}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.9009827, z: -0.5373914}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &684986975
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 684986977}
+  - component: {fileID: 684986976}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (base - spurgear1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &684986976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684986975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 1838270707}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 1
+  _lineAPointA: {x: -0.5623944, y: 2.065656, z: -0.8511374}
+  _lineAPointB: {x: -0.5723944, y: 2.065656, z: -0.8511374}
+  _lineBPointA: {x: -0.5673944, y: 2.065656, z: -0.8511374}
+  _lineBPointB: {x: -0.5723943, y: 2.065656, z: -0.8511374}
+--- !u!4 &684986977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684986975}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.9154712, z: -0.538732}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &697948582
@@ -485,6 +816,11 @@ Transform:
   m_Children: []
   m_Father: {fileID: 505702790}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &781211674 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1412932167232329871, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &868603146 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 655791098114694471, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
@@ -514,6 +850,11 @@ MonoBehaviour:
   _dirAngleYMode: 180
   _showLog: 1
   _spurGear2Speed: 120
+--- !u!4 &868603148 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4724170828665772904, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0
@@ -714,6 +1055,54 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1029744326
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1029744328}
+  - component: {fileID: 1029744327}
+  m_Layer: 0
+  m_Name: ShuttleManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1029744327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029744326}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 53b5e41bcc6b43c429dfd4bced981886, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _revoluteJoint: {fileID: 684986976}
+  _sliderJoint: {fileID: 1330138773}
+  _gearRadius: 0.055
+  _motionDirection: -1
+--- !u!4 &1029744328
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1029744326}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -19.34599, y: -0, z: -0.86416}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1138258874
 GameObject:
   m_ObjectHideFlags: 0
@@ -813,6 +1202,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1173800556
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1173800558}
+  - component: {fileID: 1173800557}
+  m_Layer: 0
+  m_Name: SliderFreezeTestManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1173800557
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1173800556}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a3280bba06475dc408552099d8bb8949, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::SliderFreezeTestManager
+  _objectB: {fileID: 1379841809}
+  _sliderSpeed: 10
+--- !u!4 &1173800558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1173800556}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.2967, y: -0, z: -3.28688}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1182891853
 GameObject:
   m_ObjectHideFlags: 0
@@ -889,6 +1324,314 @@ Transform:
   m_Children: []
   m_Father: {fileID: 604712594}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1269233335 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 231727305130331645, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1328010411
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1328010413}
+  - component: {fileID: 1328010412}
+  m_Layer: 0
+  m_Name: XWheelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1328010412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328010411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3aaf17f18214c6e4da7f9e6f1a28da5d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _shuttle: {fileID: 868603148}
+  _xwheel1Joint: {fileID: 1943809605}
+  _xwheel2Joint: {fileID: 45031479}
+  _xwheel3Joint: {fileID: 276834150}
+  _xwheel4Joint: {fileID: 647695688}
+  _duration: 6
+  _isSignal: 0
+  _isForward: 0
+--- !u!4 &1328010413
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1328010411}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.62404, y: 0, z: -1.67435}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1330138772
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1330138774}
+  - component: {fileID: 1330138773}
+  m_Layer: 0
+  m_Name: SliderJointManager (base - vslider1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1330138773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330138772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 939cfb45f6ede8041bfff2089cdc5a0e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::SliderJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 1379841809}
+  _minPosition: -3
+  _maxPosition: 3
+  _moveDirection: {x: 0, y: 1, z: 0}
+  _lineAPointA: {x: -0.45239437, y: 1.9569062, z: -0.95738745}
+  _lineAPointB: {x: -0.45239437, y: 2.3226562, z: -0.95738745}
+  _lineBPointA: {x: -0.45210564, y: 2.1073, z: -0.962}
+  _lineBPointB: {x: -0.45210564, y: 2.1973, z: -0.962}
+  _planeAPointA: {x: -0.45239437, y: 2.3226562, z: -0.95738745}
+  _planeAPointB: {x: -0.45239437, y: 1.9569062, z: -0.95738745}
+  _planeAPointC: {x: -0.5023943, y: 2.3226562, z: -0.95738745}
+  _planeBPointA: {x: -0.50710565, y: 2.1973, z: -0.962}
+  _planeBPointB: {x: -0.45210564, y: 2.1073, z: -0.962}
+  _planeBPointC: {x: -0.45210564, y: 2.1973, z: -0.962}
+--- !u!4 &1330138774
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330138772}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36559996, y: 1.9137281, z: -0.53401244}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1379841809 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1421536145 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6506328469224593072, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1838270707 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3223819236138862146, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1911020943 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1764228532557589034, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1911642343
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1911642344}
+  - component: {fileID: 1911642347}
+  - component: {fileID: 1911642346}
+  - component: {fileID: 1911642345}
+  m_Layer: 0
+  m_Name: RevoluteAxis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1911642344
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911642343}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -40.608883, y: 29.699945, z: -63.09999}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1949523498}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!136 &1911642345
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911642343}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!23 &1911642346
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911642343}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1911642347
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1911642343}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1943809604
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1943809606}
+  - component: {fileID: 1943809605}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (base - xwheel1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1943809605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943809604}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1949523498}
+  _objectB: {fileID: 1269233335}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.016394377, y: 1.9978918, z: -0.8167308}
+  _lineAPointB: {x: -0.0314368, y: 1.9978918, z: -0.8167308}
+  _lineBPointA: {x: 0.0010631084, y: 1.9978918, z: -0.8167308}
+  _lineBPointB: {x: -0.028936863, y: 1.9978918, z: -0.8167308}
+--- !u!4 &1943809606
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943809604}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.901649, z: -0.5355591}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1949523498 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4115482821629324989, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2116198337
 GameObject:
   m_ObjectHideFlags: 0
@@ -1023,3 +1766,13 @@ SceneRoots:
   - {fileID: 1138258875}
   - {fileID: 316531324}
   - {fileID: 6325364580259595220}
+  - {fileID: 417583193}
+  - {fileID: 1173800558}
+  - {fileID: 1029744328}
+  - {fileID: 684986977}
+  - {fileID: 1330138774}
+  - {fileID: 1943809606}
+  - {fileID: 45031480}
+  - {fileID: 276834151}
+  - {fileID: 647695689}
+  - {fileID: 1328010413}

--- a/unity/Assets/Scenes/Dev/RealtimeDev.unity
+++ b/unity/Assets/Scenes/Dev/RealtimeDev.unity
@@ -172,6 +172,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &197231303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 197231305}
+  - component: {fileID: 197231304}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (vslider2 - ywheel2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &197231304
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197231303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1091068178}
+  _objectB: {fileID: 1655983169}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.8436443, y: 2.03225, z: -0.08890003}
+  _lineAPointB: {x: -0.8436443, y: 2.03225, z: -0.06390002}
+  _lineBPointA: {x: -0.8436443, y: 2.03225, z: -0.00544253}
+  _lineBPointB: {x: -0.8436443, y: 2.03225, z: 0.024557471}
+--- !u!4 &197231305
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 197231303}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36434996, y: 1.90625, z: -0.5404}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &203844586
 GameObject:
   m_ObjectHideFlags: 0
@@ -394,7 +447,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.06280005
+      value: 0.07
       objectReference: {fileID: 0}
     - target: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       propertyPath: m_LocalPosition.z
@@ -464,6 +517,46 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5558652673175236376, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.47074556
+      objectReference: {fileID: 0}
+    - target: {fileID: 5558652673175236376, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.6456327
+      objectReference: {fileID: 0}
+    - target: {fileID: 5558652673175236376, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.5000343
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566387675676505695, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.29554367
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566387675676505695, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.617894
+      objectReference: {fileID: 0}
+    - target: {fileID: 5566387675676505695, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.000017881393
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850413608935888706, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.17054081
+      objectReference: {fileID: 0}
+    - target: {fileID: 5850413608935888706, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.6231976
+      objectReference: {fileID: 0}
+    - target: {fileID: 5885960579342813652, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -5.50002
+      objectReference: {fileID: 0}
+    - target: {fileID: 5885960579342813652, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0000059604645
+      objectReference: {fileID: 0}
     - target: {fileID: 6506328469224593072, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
       propertyPath: m_LocalPosition.y
       value: -5.46937
@@ -483,6 +576,11 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 868603147}
   m_SourcePrefab: {fileID: 100100000, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+--- !u!4 &403262768 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5558652673175236376, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &417583191
 GameObject:
   m_ObjectHideFlags: 0
@@ -499,7 +597,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &417583192
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -563,6 +661,11 @@ Transform:
   - {fileID: 697948586}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &534324052 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6788797953599568303, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &604712593
 GameObject:
   m_ObjectHideFlags: 0
@@ -821,6 +924,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1412932167232329871, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
   m_PrefabInstance: {fileID: 316531324}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &798388080 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7786594982670163754, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &868603146 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 655791098114694471, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
@@ -855,6 +963,59 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 4724170828665772904, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
   m_PrefabInstance: {fileID: 316531324}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &922974221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 922974223}
+  - component: {fileID: 922974222}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (m90s1 - ywheel3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &922974222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922974221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 534324052}
+  _objectB: {fileID: 403262768}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.2859974, y: 2.0233219, z: -1.0783874}
+  _lineAPointB: {x: -0.28599793, y: 2.0233219, z: -1.063345}
+  _lineBPointA: {x: -0.2859981, y: 2.0233219, z: -1.0883447}
+  _lineBPointB: {x: -0.2859981, y: 2.0233219, z: -1.0583447}
+--- !u!4 &922974223
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922974221}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36802682, y: 1.8986859, z: -0.52863735}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0
@@ -1055,6 +1216,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1018627275
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1018627277}
+  - component: {fileID: 1018627276}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (m90s2 - ywheel1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1018627276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018627275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 798388080}
+  _objectB: {fileID: 1382162203}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.28262144, y: 2.0306606, z: 0.007099986}
+  _lineAPointB: {x: -0.2826209, y: 2.0306606, z: -0.0079425275}
+  _lineBPointA: {x: -0.28262207, y: 2.0306606, z: 0.02455742}
+  _lineBPointB: {x: -0.28262207, y: 2.0306606, z: -0.005442582}
+--- !u!4 &1018627277
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1018627275}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.36508882, y: 1.9059553, z: -0.5404}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1029744326
 GameObject:
   m_ObjectHideFlags: 0
@@ -1066,7 +1280,7 @@ GameObject:
   - component: {fileID: 1029744328}
   - component: {fileID: 1029744327}
   m_Layer: 0
-  m_Name: ShuttleManager
+  m_Name: RackAndPinionManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1103,6 +1317,60 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1049395616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1049395618}
+  - component: {fileID: 1049395617}
+  m_Layer: 0
+  m_Name: SpurGearManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1049395617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049395616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6bdc7ed0fd070fc42a6f829be7b0b567, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _shuttle: {fileID: 868603148}
+  _spurGear1Joint: {fileID: 684986976}
+  _duration: 3
+  _isSignal: 0
+  _isForward: 1
+--- !u!4 &1049395618
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049395616}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.67203, y: 0, z: 7.23387}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1091068178 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8696188053732637973, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1138258874
 GameObject:
   m_ObjectHideFlags: 0
@@ -1218,7 +1486,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1173800557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1324,9 +1592,71 @@ Transform:
   m_Children: []
   m_Father: {fileID: 604712594}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1227319119 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: 8224738791551686054, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1246608260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1246608262}
+  - component: {fileID: 1246608261}
+  m_Layer: 0
+  m_Name: DirectionSwitchManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1246608261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1246608260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26e66333fecee0c4d92356efde9681d7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  _shuttle: {fileID: 868603148}
+  _rackAndPinion: {fileID: 1029744327}
+  _vslider1Joint: {fileID: 1330138773}
+  _spurGearController: {fileID: 1049395617}
+  _xwheel1Mesh: {fileID: 1269233337}
+  _ywheel3Mesh: {fileID: 1227319119}
+  _cooldownDuration: 0.5
+  _returnTolerance: 0.002
+--- !u!4 &1246608262
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1246608260}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.28556, y: -0, z: 2.00143}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1269233335 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 231727305130331645, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!33 &1269233337 stripped
+MeshFilter:
+  m_CorrespondingSourceObject: {fileID: 8778189888239721349, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
   m_PrefabInstance: {fileID: 316531324}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1328010411
@@ -1363,7 +1693,7 @@ MonoBehaviour:
   _xwheel2Joint: {fileID: 45031479}
   _xwheel3Joint: {fileID: 276834150}
   _xwheel4Joint: {fileID: 647695688}
-  _duration: 6
+  _duration: 7.5
   _isSignal: 0
   _isForward: 0
 --- !u!4 &1328010413
@@ -1412,8 +1742,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: SmartSortScripts::SliderJointComponent
   _objectA: {fileID: 1949523498}
   _objectB: {fileID: 1379841809}
-  _minPosition: -3
-  _maxPosition: 3
+  _minPosition: -100
+  _maxPosition: 100
   _moveDirection: {x: 0, y: 1, z: 0}
   _lineAPointA: {x: -0.45239437, y: 1.9569062, z: -0.95738745}
   _lineAPointB: {x: -0.45239437, y: 2.3226562, z: -0.95738745}
@@ -1445,9 +1775,129 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1925592068757491671, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
   m_PrefabInstance: {fileID: 316531324}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &1382162203 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5566387675676505695, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1421536145 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6506328469224593072, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1480237216 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5850413608935888706, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
+  m_PrefabInstance: {fileID: 316531324}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1612469894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1612469896}
+  - component: {fileID: 1612469897}
+  m_Layer: 0
+  m_Name: YWheelManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1612469896
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1612469894}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.62404, y: 0, z: -1.67435}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1612469897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1612469894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4bf59b29b7ca13a4cae8ef8825f9684a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::YWheelController
+  _shuttle: {fileID: 868603148}
+  _ywheel1Joint: {fileID: 1018627276}
+  _ywheel2Joint: {fileID: 197231304}
+  _ywheel3Joint: {fileID: 922974222}
+  _ywheel4Joint: {fileID: 1646175038}
+  _duration: 7.5
+  _isSignal: 0
+  _isForward: 0
+--- !u!1 &1646175037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1646175039}
+  - component: {fileID: 1646175038}
+  m_Layer: 0
+  m_Name: RevoluteJointManager (vslider1 - ywheel4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1646175038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646175037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64024d3310e331548bbdc597e262d972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: SmartSortScripts::RevoluteJointComponent
+  _objectA: {fileID: 1379841809}
+  _objectB: {fileID: 1480237216}
+  _minAngle: -90
+  _maxAngle: 90
+  _useClamp: 0
+  _lineAPointA: {x: -0.8505051, y: 2.024281, z: -0.9823874}
+  _lineAPointB: {x: -0.8505051, y: 2.024281, z: -1.0073874}
+  _lineBPointA: {x: -0.8505051, y: 2.024281, z: -1.0658449}
+  _lineBPointB: {x: -0.8505051, y: 2.024281, z: -1.095845}
+--- !u!4 &1646175039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646175037}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.3672763, y: 1.8987421, z: -0.53238744}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &1655983169 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5885960579342813652, guid: a5945cd2f06d4274d8e367f236f9cfe0, type: 3}
   m_PrefabInstance: {fileID: 316531324}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1838270707 stripped
@@ -1768,7 +2218,6 @@ SceneRoots:
   - {fileID: 6325364580259595220}
   - {fileID: 417583193}
   - {fileID: 1173800558}
-  - {fileID: 1029744328}
   - {fileID: 684986977}
   - {fileID: 1330138774}
   - {fileID: 1943809606}
@@ -1776,3 +2225,11 @@ SceneRoots:
   - {fileID: 276834151}
   - {fileID: 647695689}
   - {fileID: 1328010413}
+  - {fileID: 1612469896}
+  - {fileID: 1049395618}
+  - {fileID: 1029744328}
+  - {fileID: 1246608262}
+  - {fileID: 1646175039}
+  - {fileID: 1018627277}
+  - {fileID: 197231305}
+  - {fileID: 922974223}

--- a/unity/Assets/Scripts/Controllers/JointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/JointComponent.cs
@@ -17,7 +17,7 @@ public abstract class JointComponent : MonoBehaviour
     [SerializeField] protected Transform _objectA;   // 오브젝트 A (기준)
     [SerializeField] protected Transform _objectB;   // 오브젝트 B (이동 또는 회전 대상)
 
-    public Transform ObjectB => _objectB;  // [2026.04.22 추가] 오브젝트 B (이동 또는 회전 대상)
+    public Transform ObjectB => _objectB;            // [2026.04.22 추가] 오브젝트 B (이동 또는 회전 대상)
 
     protected bool _wasConstrained;                  // 이전 프레임 구속 상태 (구속 상태 변경 로그용)
 

--- a/unity/Assets/Scripts/Controllers/JointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/JointComponent.cs
@@ -1,10 +1,13 @@
 // ============================================================
 // 파일명  : JointComponent.cs
 // 역할    : SliderJointComponent 와 RevoluteJointComponent 의 공통 기반 추상 클래스
-//           Rigidbody 초기화, 구속 상태 로그, Update 공통 흐름을 담당한다.
+//           구속 상태 로그, Update 공통 흐름을 담당한다.
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - 구속 후 useGravity 활성화 코드 제거 (중력 비활성화 유지)
+//                      - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        (디지털 트윈 특성상 물리 엔진 불필요)
+//                      - ObjectB 프로퍼티 추가 (외부에서 오브젝트 B 접근용)
 // ============================================================
 
 using UnityEngine;
@@ -14,18 +17,15 @@ public abstract class JointComponent : MonoBehaviour
     [SerializeField] protected Transform _objectA;   // 오브젝트 A (기준)
     [SerializeField] protected Transform _objectB;   // 오브젝트 B (이동 또는 회전 대상)
 
-    protected Rigidbody _rigidbodyA;                   // 오브젝트 A 리지드바디
-    protected Rigidbody _rigidbodyB;                   // 오브젝트 B 리지드바디
-    protected RigidbodyConstraints _freezeConstraint;  // 프리즈 조건 (캐시)
+    public Transform ObjectB => _objectB;  // [2026.04.22 추가] 오브젝트 B (이동 또는 회전 대상)
 
-    protected bool _wasConstrained;                    // 이전 프레임 구속 상태
+    protected bool _wasConstrained;                  // 이전 프레임 구속 상태 (구속 상태 변경 로그용)
 
-    protected const float ApplyTolerance = 0.001f;     // 물리 적용 판별 허용 오차 (Line/Plane 의 Tolerance 1e-6f 와 구분)
+    protected const float ApplyTolerance = 0.001f;   // 물리 적용 판별 허용 오차 (Line/Plane 의 Tolerance 1e-6f 와 구분)
 
     /**
      * @brief  공통 Awake 처리.
-     *         Rigidbody 초기화 → 중력 비활성화 → 프리즈 조건 계산 → 자식 전용 초기화(OnAwake) 순서로 실행한다.
-     *         구속 확인 전 오브젝트 B 가 중력으로 떨어지는 것을 방지하기 위해 초기에 중력을 비활성화한다.
+     *         유효성 검사 → 자식 전용 초기화 순서로 실행한다.
      */
     protected virtual void Awake()
     {
@@ -35,13 +35,7 @@ public abstract class JointComponent : MonoBehaviour
             enabled = false;  // Update 호출 중단 (NullReferenceException 방지)
             return;
         }
-        _rigidbodyA = InitializeRigidbody(_objectA, true);
-        _rigidbodyB = InitializeRigidbody(_objectB, false);
 
-        // 구속 확인 전 중력으로 떨어지는 것을 방지하기 위해 초기에 중력 비활성화
-        _rigidbodyB.useGravity = false;
-
-        _freezeConstraint = GetFreezeConstraintByDirection();
         InitializeChild();
     }
 
@@ -50,41 +44,33 @@ public abstract class JointComponent : MonoBehaviour
     /**
      * @brief  공통 Update 처리. (임시 - 추후 FixedUpdate 로 변경 예정)
      *         IsValid → ApplyConstraint → 구속 상태 변경 로그 → 구속/해제 분기 순서로 실행한다.
-     *         구속됨 상태일 때만 중력을 활성화하고, 구속 안 됨 상태일 때는 중력을 비활성화한다.
      */
     protected virtual void Update()
     {
         if (!IsJointValid()) return;
 
-        bool isConstrained = ApplyJointConstraint();
+        bool isConstrained = ApplyJointConstraint();  // 구속 조건 적용 결과
 
         // 구속 상태가 변경됐을 때만 로그 출력
         if (isConstrained != _wasConstrained)
         {
             Debug.Log($"{GetType().Name} 구속 상태 변경: {(isConstrained ? "구속됨" : "해제됨")}");
-            _wasConstrained = isConstrained;
+            _wasConstrained = isConstrained;  // 이전 프레임 구속 상태 갱신
         }
 
         if (isConstrained)
         {
-            _rigidbodyB.useGravity = true;   // 구속됨 → 중력 활성화
-            _rigidbodyB.constraints = _freezeConstraint;
-            OnConstrained();
-        }
-        else
-        {
-            _rigidbodyB.useGravity = false;  // 구속 안 됨 → 중력 비활성화
-            _rigidbodyB.constraints = RigidbodyConstraints.None;
+            OnConstrained();  // 구속 상태일 때 자식 클래스 전용 처리
         }
     }
 
     /**
-    * @brief  Inspector 에서 값 변경 시 공통 유효성 검사 후 자식 전용 재초기화를 호출한다.
-    *         ※ Play 모드에서는 실행되지 않는다.
-    */
+     * @brief  Inspector 에서 값 변경 시 공통 유효성 검사 후 자식 전용 재초기화를 호출한다.
+     *         ※ Play 모드에서는 실행되지 않는다.
+     */
     protected void OnValidate()
     {
-        if (Application.isPlaying) return;
+        if (Application.isPlaying) return;  // Play 모드에서는 실행하지 않는다
         if (_objectA == null || _objectB == null) return;
         OnValidateJoint();
     }
@@ -96,9 +82,9 @@ public abstract class JointComponent : MonoBehaviour
     protected abstract void InitializeChild();
 
     /**
-    * @brief  Inspector 에서 값 변경 시 자식 클래스 전용 재초기화.
-    *         Line·Plane·Joint 인스턴스를 자식에서 재생성한다.
-    */
+     * @brief  Inspector 에서 값 변경 시 자식 클래스 전용 재초기화.
+     *         Line·Plane·Joint 인스턴스를 자식에서 재생성한다.
+     */
     protected abstract void OnValidateJoint();
 
     /**
@@ -117,42 +103,7 @@ public abstract class JointComponent : MonoBehaviour
 
     /**
      * @brief  구속 상태일 때 자식 클래스 전용 처리.
-     *         MovePosition 또는 MoveRotation 을 여기서 호출한다.
+     *         Transform 직접 제어로 위치 또는 회전을 적용한다.
      */
     protected abstract void OnConstrained();
-
-    /**
-     * @brief  이동 또는 회전 방향 축을 감지하여 해당 축만 열어두고
-     *         나머지를 프리즈한 RigidbodyConstraints 를 반환한다.
-     *         자식 클래스에서 FreezePosition / FreezeRotation 중 하나를 선택하여 구현한다.
-     * @return RigidbodyConstraints  축 방향에 맞는 프리즈 조건
-     */
-    protected abstract RigidbodyConstraints GetFreezeConstraintByDirection();
-
-    /**
-     * @brief  오브젝트의 Rigidbody 를 가져온다.
-     *         Rigidbody 가 없으면 자동으로 생성한다.
-     *         shouldBeKinematic 이 true 이고 Rigidbody 가 Kinematic 이 아니면
-     *         자동으로 Kinematic 으로 설정하고 로그를 출력한다.
-     * @param  target              대상 오브젝트의 Transform
-     * @param  shouldBeKinematic   true 이면 Rigidbody 를 Kinematic 으로 설정한다.
-     *                             (오브젝트 A 고정용)
-     * @return Rigidbody           가져오거나 생성한 Rigidbody
-     */
-    protected Rigidbody InitializeRigidbody(Transform target, bool shouldBeKinematic)
-    {
-        Rigidbody rb = target.GetComponent<Rigidbody>();
-        if (rb == null)
-        {
-            rb = target.gameObject.AddComponent<Rigidbody>();
-        }
-
-        if (shouldBeKinematic && !rb.isKinematic)
-        {
-            rb.isKinematic = true;
-            Debug.Log($"{GetType().Name}: Object A 가 자동으로 고정되었습니다.\n고정 대상을 변경하려면 Inspector 에서 Is Kinematic 을 수동으로 설정해주세요.");
-        }
-
-        return rb;
-    }
 }

--- a/unity/Assets/Scripts/Controllers/RevoluteJointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/RevoluteJointComponent.cs
@@ -1,74 +1,99 @@
 // ============================================================
 // 파일명  : RevoluteJointComponent.cs
-// 역할    : RevoluteJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트
+// 역할    : RevoluteJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트.
+//           회전축(Line) 을 기반으로 RevoluteJoint 를 초기화하고
+//           외부에서 SetAngle() 로 회전 각도를 직접 제어한다.
+//           셔틀이 이동해도 부모 기준 로컬 좌표(_localLineBCenter) 를
+//           월드 좌표로 역변환하여 LineBCenter 를 올바르게 유지한다.
+//
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 2026-04-22 - _lineAPointA/B, _lineBPointA/B 추가 (ConstraintAssemblyWindow 에서 저장)
-//                      - InitializeChild() 에서 저장된 점 좌표로 Line 생성하도록 변경
-//                      - OnValidateJoint() 에서 저장된 점 좌표로 Line 생성하도록 변경
-//                      - ObjectBRotationAxis, LineBCenter 프로퍼티 추가
-//                      - OnClampedCallback 추가 (클램프 후 동기화용)
-//                      - OnConstrained() 에서 _objectBRotationAxis 매 프레임 갱신 제거
-//                        (회전축 불안정으로 인한 각도 계산 오류 수정)
-//                      - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
-//                        (디지털 트윈 특성상 물리 엔진 불필요)
-//                      - _rotationAxis 제거 (미사용 필드, _lineBPointA/B 로 대체됨)
-//                      - _useClamp 추가 (클램프 사용 여부 선택 가능, 기본값 true)
+// 수정이력: 2026-04-27 - _lineAPointA/B, _lineBPointA/B 추가
+//                        ObjectBRotationAxis, LineBCenter 프로퍼티 추가
+//                        OnClampedCallback 추가
+//                        _useClamp 추가 (기본값 true)
+//                        Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        _localLineBCenter 추가 (부모 기준 로컬 좌표)
+//                        LineBCenter 프로퍼티를 로컬 좌표 기반으로 변경
 // ============================================================
 
 using UnityEngine;
 
 public class RevoluteJointComponent : JointComponent
 {
-    [SerializeField] private float _minAngle = -90f;                    // 최소 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
-    [SerializeField] private float _maxAngle = 90f;                     // 최대 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
-    [SerializeField] private bool _useClamp = true;                     // 클램프 사용 여부 (false 면 무한 회전 가능)
+    // ============================================================
+    // Inspector 필드
+    // ============================================================
 
-    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 회전축 Line 점 좌표
-    [SerializeField] private Vector3 _lineAPointA;  // Object A 회전축 Line 시작점
-    [SerializeField] private Vector3 _lineAPointB;  // Object A 회전축 Line 끝점
-    [SerializeField] private Vector3 _lineBPointA;  // Object B 회전축 Line 시작점
-    [SerializeField] private Vector3 _lineBPointB;  // Object B 회전축 Line 끝점
+    [Header("회전 범위")]
+    [SerializeField] private float _minAngle = -90f; // 최소 회전 각도 (degree, ObjectB 초기 회전 기준)
+    [SerializeField] private float _maxAngle = 90f; // 최대 회전 각도 (degree, ObjectB 초기 회전 기준)
+    [SerializeField] private bool _useClamp = true; // 클램프 사용 여부 (false 면 무한 회전)
 
-    private RevoluteJoint _joint;           // RevoluteJoint.cs 인스턴스
-    private Vector3 _initialDirection;      // 초기 기준 방향 (각도 측정용)
-    private Quaternion _initialRotation;    // 초기 회전값 (최종 회전 적용용)
-    private Vector3 _objectBRotationAxis;   // 오브젝트 B 기준 회전축
+    [Header("회전축 Line 좌표 (ConstraintAssemblyWindow 저장값)")]
+    [SerializeField] private Vector3 _lineAPointA; // ObjectA 회전축 시작점
+    [SerializeField] private Vector3 _lineAPointB; // ObjectA 회전축 끝점
+    [SerializeField] private Vector3 _lineBPointA; // ObjectB 회전축 시작점 (LineBCenter 기준)
+    [SerializeField] private Vector3 _lineBPointB; // ObjectB 회전축 끝점
 
-    public float CurrentAngle => _joint?.CurrentAngle ?? 0f;        // 현재 회전 각도
-    public Vector3 ObjectBRotationAxis => _objectBRotationAxis;     // [2026.04.22 추가] 오브젝트 B 기준 회전축
-    public Vector3 LineBCenter => _lineBPointA;                     // [2026.04.22 추가] lineB 시작점 (위치 보정 기준)
+    // ============================================================
+    // 런타임 상태
+    // ============================================================
 
-    // [2026.04.22 추가] 클램프 후 콜백 (RevoluteFreezeTestManager 동기화용)
+    private RevoluteJoint _joint;
+    private Vector3 _initialDirection;    // 초기 기준 방향 (각도 측정 기준점)
+    private Quaternion _initialRotation;     // 초기 회전값 (최종 회전 적용 기준점)
+    private Vector3 _objectBRotationAxis; // ObjectB 기준 회전축 방향
+    private Vector3 _localLineBCenter;    // 부모 기준 로컬 LineBCenter (셔틀 이동 추적용)
+
+    // ============================================================
+    // 프로퍼티
+    // ============================================================
+
+    public float CurrentAngle => _joint?.CurrentAngle ?? 0f;
+    public Vector3 ObjectBRotationAxis => _objectBRotationAxis;
+
+    /// 셔틀이 이동해도 부모→월드 변환으로 항상 올바른 LineBCenter 를 반환한다.
+    public Vector3 LineBCenter => _objectB.parent != null
+        ? _objectB.parent.TransformPoint(_localLineBCenter)
+        : _localLineBCenter;
+
+    // ============================================================
+    // 이벤트
+    // ============================================================
+
+    /// 클램프 발생 시 외부로 보정된 회전값을 전달한다. (SpurGearController 동기화용)
     public System.Action<Quaternion> OnClampedCallback;
 
+    // ============================================================
+    // JointComponent 구현
+    // ============================================================
+
     /**
-     * @brief  회전축 Line 을 생성하고 RevoluteJoint 를 초기화한다.
-     *         초기 기준 방향(_initialDirection) 과 초기 회전값(_initialRotation) 을 저장한다.
+     * @brief  회전축 Line 으로 RevoluteJoint 를 초기화한다.
+     *         초기 회전값과 기준 방향을 저장하고
+     *         LineBCenter 를 부모 기준 로컬 좌표로 저장하여
+     *         셔틀 이동 후에도 올바른 위치를 반환할 수 있게 한다.
      */
     protected override void InitializeChild()
     {
-        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
         Line lineA = new Line(_lineAPointA, _lineAPointB);
         Line lineB = new Line(_lineBPointA, _lineBPointB);
 
-        // [2026.04.22 수정] lineB 방향으로 초기 회전축 설정
         _objectBRotationAxis = lineB.Direction;
-
-        // RevoluteJoint.cs 인스턴스 생성
         _joint = new RevoluteJoint(lineA, lineB, _minAngle, _maxAngle);
-
-        // 초기 회전값 저장 (클램프 계산의 기준점)
         _initialRotation = _objectB.rotation;
 
-        // [2026.04.22 수정] 회전축과 수직인 벡터를 월드 좌표로 구한다
-        Vector3 perpendicular = Vector3.Cross(_objectBRotationAxis, Vector3.forward);
+        _localLineBCenter = _objectB.parent != null
+            ? _objectB.parent.InverseTransformPoint(_lineBPointA)
+            : _lineBPointA;
 
-        // [2026.04.22 수정] 회전축과 forward 가 평행할 때 forward 대신 right 로 대체
+        // 회전축과 수직인 초기 기준 방향 벡터 계산
+        // forward 와 평행할 경우 right 로 대체
+        Vector3 perpendicular = Vector3.Cross(_objectBRotationAxis, Vector3.forward);
         if (perpendicular.magnitude < ApplyTolerance)
             perpendicular = Vector3.Cross(_objectBRotationAxis, Vector3.right);
 
-        // 초기 기준 방향 저장 (각도 측정의 기준점)
         _initialDirection = perpendicular.normalized;
     }
 
@@ -78,12 +103,11 @@ public class RevoluteJointComponent : JointComponent
      */
     protected override bool IsJointValid()
     {
-        if (_joint == null) return false;
-        return _joint.IsValid();
+        return _joint != null && _joint.IsValid();
     }
 
     /**
-     * @brief  RevoluteJoint 구속 조건 적용.
+     * @brief  RevoluteJoint 구속 조건을 적용한다.
      * @return bool  구속 중이면 true
      */
     protected override bool ApplyJointConstraint()
@@ -91,24 +115,19 @@ public class RevoluteJointComponent : JointComponent
         return _joint.ApplyConstraint();
     }
 
-    //TODO: 추후에 다시 확인 - 프리즈 대신 '구속 조건이 풀리면 → 다시 구속 위치로 이동' 구현 예정
-    //      현재는 구속 조건 확인을 위한 임시 프리즈 처리
     /**
-     * @brief  구속 상태일 때 오브젝트 B 의 회전을 클램프하여 적용한다.
-     *         _useClamp 가 false 이면 클램프 없이 각도 상태값만 동기화한다.
-     *         Transform 직접 제어로 회전을 적용한다.
+     * @brief  구속 상태일 때 ObjectB 의 회전을 클램프하여 적용한다.
+     *         _useClamp=false 이면 클램프 없이 각도 상태값만 동기화한다.
+     *         범위를 초과한 경우 GetClampedRotation() 으로 보정하고
+     *         OnClampedCallback 이벤트를 발행한다.
      */
     protected override void OnConstrained()
     {
-        // [2026.04.22 수정] _objectBRotationAxis 매 프레임 갱신 제거
-        // InitializeChild() 에서 한 번만 설정한 값을 그대로 사용
         Quaternion deltaRotation = _objectB.rotation * Quaternion.Inverse(_initialRotation);
-        Vector3 currentDirection = (deltaRotation * _initialDirection).normalized;  // 현재 방향 벡터
-
+        Vector3 currentDirection = (deltaRotation * _initialDirection).normalized;
         float currentAngle = RevoluteJoint.GetCurrentAngle(
-            _initialDirection, currentDirection, _objectBRotationAxis);  // 현재 회전 각도
+            _initialDirection, currentDirection, _objectBRotationAxis);
 
-        // [2026.04.22 추가] 클램프 비활성화 시 각도 상태값만 동기화하고 회전은 건드리지 않음
         if (!_useClamp)
         {
             _joint.SetAngle(currentAngle);
@@ -117,44 +136,45 @@ public class RevoluteJointComponent : JointComponent
 
         if (currentAngle < _minAngle || currentAngle > _maxAngle)
         {
-            // [2026.04.22 수정] MoveRotation → Transform 직접 제어
             Quaternion clampedRot = _joint.GetClampedRotation(
                 _initialDirection, currentDirection, _objectBRotationAxis, _initialRotation);
-            _objectB.rotation = clampedRot;  // Transform 직접 제어
+            _objectB.rotation = clampedRot;
             OnClampedCallback?.Invoke(clampedRot);
         }
         else
         {
-            _joint.SetAngle(currentAngle);  // 범위 내에 있을 때 각도 상태값 동기화
+            _joint.SetAngle(currentAngle);
         }
     }
 
     /**
-     * @brief  외부에서 회전 각도를 설정한다.
-     *         ShuttleController.cs 에서 호출한다.
-     * @param  angle    설정할 회전 각도 (degree)
-     */
-    public void SetAngle(float angle)
-    {
-        if (_joint == null) return;
-
-        _joint.SetAngle(angle);  // 내부 상태값 업데이트 (min/max 클램프 처리됨)
-
-        // [2026.04.22 수정] MoveRotation → Transform 직접 제어
-        _objectB.rotation = Quaternion.AngleAxis(_joint.CurrentAngle, _objectBRotationAxis) * _initialRotation;
-    }
-
-    /**
-     * @brief  Inspector 에서 값 변경 시 Line 을 재생성하고 RevoluteJoint 를 재초기화한다.
-     *         ※ Play 모드에서는 실행되지 않는다.
+     * @brief  Inspector 값 변경 시 RevoluteJoint 를 재초기화한다.
+     *         Play 모드에서는 실행되지 않는다.
+     *         Line 좌표가 미설정(zero) 이면 초기화를 건너뛴다.
      */
     protected override void OnValidateJoint()
     {
-        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
         if (_lineAPointA == Vector3.zero && _lineAPointB == Vector3.zero) return;
 
         Line lineA = new Line(_lineAPointA, _lineAPointB);
         Line lineB = new Line(_lineBPointA, _lineBPointB);
         _joint = new RevoluteJoint(lineA, lineB, _minAngle, _maxAngle);
+    }
+
+    // ============================================================
+    // 공개 메서드
+    // ============================================================
+
+    /**
+     * @brief  회전 각도를 외부에서 직접 설정한다.
+     *         내부 상태값 업데이트 후 ObjectB 의 rotation 을 갱신한다.
+     * @param  angle  설정할 회전 각도 (degree)
+     */
+    public void SetAngle(float angle)
+    {
+        if (_joint == null) return;
+
+        _joint.SetAngle(angle);
+        _objectB.rotation = Quaternion.AngleAxis(_joint.CurrentAngle, _objectBRotationAxis) * _initialRotation;
     }
 }

--- a/unity/Assets/Scripts/Controllers/RevoluteJointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/RevoluteJointComponent.cs
@@ -3,25 +3,44 @@
 // 역할    : RevoluteJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - _lineAPointA/B, _lineBPointA/B 추가 (ConstraintAssemblyWindow 에서 저장)
+//                      - InitializeChild() 에서 저장된 점 좌표로 Line 생성하도록 변경
+//                      - OnValidateJoint() 에서 저장된 점 좌표로 Line 생성하도록 변경
+//                      - ObjectBRotationAxis, LineBCenter 프로퍼티 추가
+//                      - OnClampedCallback 추가 (클램프 후 동기화용)
+//                      - OnConstrained() 에서 _objectBRotationAxis 매 프레임 갱신 제거
+//                        (회전축 불안정으로 인한 각도 계산 오류 수정)
+//                      - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        (디지털 트윈 특성상 물리 엔진 불필요)
+//                      - _rotationAxis 제거 (미사용 필드, _lineBPointA/B 로 대체됨)
+//                      - _useClamp 추가 (클램프 사용 여부 선택 가능, 기본값 true)
 // ============================================================
 
 using UnityEngine;
 
 public class RevoluteJointComponent : JointComponent
 {
-    [SerializeField] private float _minAngle = -90f;                     // 최소 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
-    [SerializeField] private float _maxAngle = 90f;                      // 최대 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
-    [SerializeField] private Vector3 _rotationAxis = Vector3.right;      // 회전축(월드기준)
+    [SerializeField] private float _minAngle = -90f;                    // 최소 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
+    [SerializeField] private float _maxAngle = 90f;                     // 최대 회전 각도 - 오브젝트 B 초기 회전 상태 기준 (degree)
+    [SerializeField] private bool _useClamp = true;                     // 클램프 사용 여부 (false 면 무한 회전 가능)
 
-    private RevoluteJoint _joint;              // RevoluteJoint.cs 인스턴스
-    private Vector3 _initialDirection;         // 초기 기준 방향 (각도 측정용)
-    private Quaternion _initialRotation;       // 초기 회전값 (최종 회전 적용용)
-    private Vector3 _objectBRotationAxis;      // 오브젝트 B 기준 회전축
+    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 회전축 Line 점 좌표
+    [SerializeField] private Vector3 _lineAPointA;  // Object A 회전축 Line 시작점
+    [SerializeField] private Vector3 _lineAPointB;  // Object A 회전축 Line 끝점
+    [SerializeField] private Vector3 _lineBPointA;  // Object B 회전축 Line 시작점
+    [SerializeField] private Vector3 _lineBPointB;  // Object B 회전축 Line 끝점
 
-    public float CurrentAngle => _joint?.CurrentAngle ?? 0f;    // 현재 회전 각도
-    public Vector3 ObjectBRotationAxis => _objectBRotationAxis;     // 오브젝트 B 기준 회전축
+    private RevoluteJoint _joint;           // RevoluteJoint.cs 인스턴스
+    private Vector3 _initialDirection;      // 초기 기준 방향 (각도 측정용)
+    private Quaternion _initialRotation;    // 초기 회전값 (최종 회전 적용용)
+    private Vector3 _objectBRotationAxis;   // 오브젝트 B 기준 회전축
 
+    public float CurrentAngle => _joint?.CurrentAngle ?? 0f;        // 현재 회전 각도
+    public Vector3 ObjectBRotationAxis => _objectBRotationAxis;     // [2026.04.22 추가] 오브젝트 B 기준 회전축
+    public Vector3 LineBCenter => _lineBPointA;                     // [2026.04.22 추가] lineB 시작점 (위치 보정 기준)
+
+    // [2026.04.22 추가] 클램프 후 콜백 (RevoluteFreezeTestManager 동기화용)
+    public System.Action<Quaternion> OnClampedCallback;
 
     /**
      * @brief  회전축 Line 을 생성하고 RevoluteJoint 를 초기화한다.
@@ -29,13 +48,12 @@ public class RevoluteJointComponent : JointComponent
      */
     protected override void InitializeChild()
     {
-        _objectBRotationAxis = _rotationAxis; // 초기 축 설정
+        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
+        Line lineA = new Line(_lineAPointA, _lineAPointB);
+        Line lineB = new Line(_lineBPointA, _lineBPointB);
 
-        // 오브젝트 A·B 의 Transform 에서 회전축 Line 생성
-        Line lineA = new Line(_objectA.position,
-                              _objectA.position + _rotationAxis);
-        Line lineB = new Line(_objectB.position,
-                              _objectB.position + _rotationAxis);
+        // [2026.04.22 수정] lineB 방향으로 초기 회전축 설정
+        _objectBRotationAxis = lineB.Direction;
 
         // RevoluteJoint.cs 인스턴스 생성
         _joint = new RevoluteJoint(lineA, lineB, _minAngle, _maxAngle);
@@ -43,20 +61,14 @@ public class RevoluteJointComponent : JointComponent
         // 초기 회전값 저장 (클램프 계산의 기준점)
         _initialRotation = _objectB.rotation;
 
-        // 생성한 lineB의 방향을 회전축으로 사용
-        Vector3 axis = lineB.Direction;
+        // [2026.04.22 수정] 회전축과 수직인 벡터를 월드 좌표로 구한다
+        Vector3 perpendicular = Vector3.Cross(_objectBRotationAxis, Vector3.forward);
 
-        // 회전축과 수직인 벡터를 월드 좌표로 구한다
-        Vector3 perpendicular = Vector3.Cross(axis, Vector3.forward);
-
-        // 회전축과 forward 가 평행할 때 forward 대신 right 로 대체
+        // [2026.04.22 수정] 회전축과 forward 가 평행할 때 forward 대신 right 로 대체
         if (perpendicular.magnitude < ApplyTolerance)
-        {
-            perpendicular = Vector3.Cross(axis, Vector3.right);
-        }
+            perpendicular = Vector3.Cross(_objectBRotationAxis, Vector3.right);
 
-        // 초기 기준 방향을 월드 좌표로 저장 (오브젝트 회전 적용 없이)
-        // 이 벡터는 각도 측정의 기준점이 된다
+        // 초기 기준 방향 저장 (각도 측정의 기준점)
         _initialDirection = perpendicular.normalized;
     }
 
@@ -67,7 +79,6 @@ public class RevoluteJointComponent : JointComponent
     protected override bool IsJointValid()
     {
         if (_joint == null) return false;
-
         return _joint.IsValid();
     }
 
@@ -84,56 +95,53 @@ public class RevoluteJointComponent : JointComponent
     //      현재는 구속 조건 확인을 위한 임시 프리즈 처리
     /**
      * @brief  구속 상태일 때 오브젝트 B 의 회전을 클램프하여 적용한다.
+     *         _useClamp 가 false 이면 클램프 없이 각도 상태값만 동기화한다.
+     *         Transform 직접 제어로 회전을 적용한다.
      */
     protected override void OnConstrained()
     {
-        // 구속 상태가 확인된 이후에는 실제로 생성된 lineB의 방향을 회전축으로 사용한다
-        // RevoluteJoint.Axis는 lineB가 존재하면 그 방향을 반환하므로 이를 우선 사용
-        _objectBRotationAxis = _joint != null ? _joint.Axis : (_objectA.rotation * _rotationAxis);
-
-        // 순수 회전량 계산: 초기 회전의 역회전 * 현재 회전
-        // 이렇게 하면 초기 상태 대비 얼마나 회전했는지만 알 수 있다
+        // [2026.04.22 수정] _objectBRotationAxis 매 프레임 갱신 제거
+        // InitializeChild() 에서 한 번만 설정한 값을 그대로 사용
         Quaternion deltaRotation = _objectB.rotation * Quaternion.Inverse(_initialRotation);
+        Vector3 currentDirection = (deltaRotation * _initialDirection).normalized;  // 현재 방향 벡터
 
-        // 현재 방향: 초기 기준 방향을 순수 회전량만큼 회전시킨 결과
-        Vector3 currentDirection = (deltaRotation * _initialDirection).normalized;
+        float currentAngle = RevoluteJoint.GetCurrentAngle(
+            _initialDirection, currentDirection, _objectBRotationAxis);  // 현재 회전 각도
 
-        // 현재 회전 각도를 계산한다
-        float currentAngle = RevoluteJoint.GetCurrentAngle(_initialDirection, currentDirection, _objectBRotationAxis);
+        // [2026.04.22 추가] 클램프 비활성화 시 각도 상태값만 동기화하고 회전은 건드리지 않음
+        if (!_useClamp)
+        {
+            _joint.SetAngle(currentAngle);
+            return;
+        }
 
-        // 클램프가 필요한 경우만 적용 (min/max 범위 밖일 때만)
-        // 범위 안에 있으면 회전을 건드리지 않아 덜덜거림을 방지한다
         if (currentAngle < _minAngle || currentAngle > _maxAngle)
         {
+            // [2026.04.22 수정] MoveRotation → Transform 직접 제어
             Quaternion clampedRot = _joint.GetClampedRotation(
                 _initialDirection, currentDirection, _objectBRotationAxis, _initialRotation);
-            _rigidbodyB.MoveRotation(clampedRot);
+            _objectB.rotation = clampedRot;  // Transform 직접 제어
+            OnClampedCallback?.Invoke(clampedRot);
+        }
+        else
+        {
+            _joint.SetAngle(currentAngle);  // 범위 내에 있을 때 각도 상태값 동기화
         }
     }
 
     /**
      * @brief  외부에서 회전 각도를 설정한다.
-     *         ShuttleController.cs 에서 임펠러 각도 제어 시 호출한다.
-     *         Rigidbody.MoveRotation()과 Transform.rotation을 즉시 동기화하여
-     *         Update() → OnConstrained() 실행 시 타이밍 충돌을 방지하고
-     *         프레임 지연 없이 즉각적인 회전 제어를 수행한다.
+     *         ShuttleController.cs 에서 호출한다.
      * @param  angle    설정할 회전 각도 (degree)
      */
     public void SetAngle(float angle)
     {
-        if (_joint == null || _rigidbodyB == null) return;
+        if (_joint == null) return;
 
-        // 로직 클래스의 상태값을 먼저 업데이트 (내부에서 min/max 클램프 처리됨)
-        _joint.SetAngle(angle);
+        _joint.SetAngle(angle);  // 내부 상태값 업데이트 (min/max 클램프 처리됨)
 
-        // 클램프된 결과값(_joint.CurrentAngle)을 바탕으로 목표 회전값 계산
-        Quaternion targetRotation = Quaternion.AngleAxis(_joint.CurrentAngle, _objectBRotationAxis) * _initialRotation;
-
-        // 물리 회전 명령 및 Transform 즉시 동기화
-        // Transform을 즉시 반영하여 다음 Update/FixedUpdate에서
-        // OnConstrained()가 이전 회전을 기준으로 재계산하는 문제를 방지
-        _rigidbodyB.MoveRotation(targetRotation);
-        _objectB.rotation = targetRotation;
+        // [2026.04.22 수정] MoveRotation → Transform 직접 제어
+        _objectB.rotation = Quaternion.AngleAxis(_joint.CurrentAngle, _objectBRotationAxis) * _initialRotation;
     }
 
     /**
@@ -142,36 +150,11 @@ public class RevoluteJointComponent : JointComponent
      */
     protected override void OnValidateJoint()
     {
-        // 오브젝트 A·B 의 Transform 에서 회전축 Line 생성
-        Line lineA = new Line(_objectA.position,
-                              _objectA.position + _rotationAxis);
-        Line lineB = new Line(_objectB.position,
-                              _objectB.position + _rotationAxis);
+        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
+        if (_lineAPointA == Vector3.zero && _lineAPointB == Vector3.zero) return;
 
+        Line lineA = new Line(_lineAPointA, _lineAPointB);
+        Line lineB = new Line(_lineBPointA, _lineBPointB);
         _joint = new RevoluteJoint(lineA, lineB, _minAngle, _maxAngle);
-    }
-
-    /**
-     * @brief  회전 축을 감지하여 해당 축의 회전만 열어두고
-     *         나머지 이동 및 회전을 프리즈한 RigidbodyConstraints 를 반환한다.
-     * @return RigidbodyConstraints  회전축의 회전만 열어둔 프리즈 조건
-     */
-    protected override RigidbodyConstraints GetFreezeConstraintByDirection()
-    {
-        // 지정된 회전축 방향과 각 축의 유사도(내적) 계산
-        // Dot 결과값의 절댓값이 클수록 해당 축과 방향이 일치함을 의미
-        // ex) _rotationAxis = (1,0,0) 이면 dotX = 1.0, dotY = 0.0, dotZ = 0.0
-        float dotX = Mathf.Abs(Vector3.Dot(_objectBRotationAxis, Vector3.right));
-        float dotY = Mathf.Abs(Vector3.Dot(_objectBRotationAxis, Vector3.up));
-        float dotZ = Mathf.Abs(Vector3.Dot(_objectBRotationAxis, Vector3.forward));
-
-        // 세 축 중 Dot 값이 가장 큰 축이 실제 회전축
-        // FreezeAll(모두 고정) 상태에서 해당 축의 회전(FreezeRotation) 제한만 해제
-        if (dotX >= dotY && dotX >= dotZ)
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezeRotationX;
-        else if (dotY >= dotX && dotY >= dotZ)
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezeRotationY;
-        else
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezeRotationZ;
     }
 }

--- a/unity/Assets/Scripts/Controllers/SliderJointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/SliderJointComponent.cs
@@ -1,61 +1,83 @@
 // ============================================================
 // 파일명  : SliderJointComponent.cs
-// 역할    : SliderJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트
+// 역할    : SliderJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트.
+//           이동축(Line)과 기준면(Plane) 을 기반으로 SliderJoint 를 초기화하고
+//           외부에서 SetPosition() 으로 슬라이더 위치를 직접 제어한다.
+//           셔틀이 X/Z 축으로 이동해도 부모 기준 로컬 좌표(_localInitialPosition) 를
+//           월드 좌표로 역변환하여 기준점을 올바르게 유지한다.
+//
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 2026-04-22 - _lineAPointA/B, _lineBPointA/B 추가 (ConstraintAssemblyWindow 에서 저장)
-//                      - _planeAPointA/B/C, _planeBPointA/B/C 추가 (ConstraintAssemblyWindow 에서 저장)
-//                      - InitializeJoint() 에서 저장된 점 좌표로 Line, Plane 생성하도록 변경
-//                      - _initialPosition 추가 (SetPosition 기준점으로 사용)
-//                      - SetPosition() 에서 _objectA.position 대신 _initialPosition 사용
-//                      - OnConstrained() 기준점을 _initialPosition 으로 통일
-//                        (SetPosition() 과 기준점 불일치로 인한 위치 누적 오차 수정)
-//                      - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
-//                        (디지털 트윈 특성상 물리 엔진 불필요)
+// 수정이력: 2026-04-27 - _lineAPointA/B, _lineBPointA/B 추가
+//                        _planeAPointA/B/C, _planeBPointA/B/C 추가
+//                        _initialPosition 추가 (SetPosition 기준점)
+//                        Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        _localInitialPosition 추가 (부모 기준 로컬 좌표)
+//                        _worldInitialY 제거
 // ============================================================
 
 using UnityEngine;
 
 public class SliderJointComponent : JointComponent
 {
-    [SerializeField] private float _minPosition = 0f;                    // 최소 이동 범위 - 오브젝트 A 위치 기준 절대값 (mm)
-    [SerializeField] private float _maxPosition = 100f;                  // 최대 이동 범위 - 오브젝트 A 위치 기준 절대값 (mm)
-    [SerializeField] private Vector3 _moveDirection = Vector3.right;     // 슬라이더 이동 방향
+    // ============================================================
+    // Inspector 필드
+    // ============================================================
 
-    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 이동축 Line 점 좌표
-    [SerializeField] private Vector3 _lineAPointA;  // Object A 이동축 Line 시작점
-    [SerializeField] private Vector3 _lineAPointB;  // Object A 이동축 Line 끝점
-    [SerializeField] private Vector3 _lineBPointA;  // Object B 이동축 Line 시작점
-    [SerializeField] private Vector3 _lineBPointB;  // Object B 이동축 Line 끝점
+    [Header("이동 범위")]
+    [SerializeField] private float _minPosition = 0f;             // 최소 이동 범위 (m, ObjectA 기준)
+    [SerializeField] private float _maxPosition = 100f;           // 최대 이동 범위 (m, ObjectA 기준)
+    [SerializeField] private Vector3 _moveDirection = Vector3.right;  // 슬라이더 이동 방향
 
-    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 기준 Plane 점 좌표
-    [SerializeField] private Vector3 _planeAPointA;  // Object A 기준 Plane 점 A
-    [SerializeField] private Vector3 _planeAPointB;  // Object A 기준 Plane 점 B
-    [SerializeField] private Vector3 _planeAPointC;  // Object A 기준 Plane 점 C
-    [SerializeField] private Vector3 _planeBPointA;  // Object B 기준 Plane 점 A
-    [SerializeField] private Vector3 _planeBPointB;  // Object B 기준 Plane 점 B
-    [SerializeField] private Vector3 _planeBPointC;  // Object B 기준 Plane 점 C
+    [Header("이동축 Line 좌표 (ConstraintAssemblyWindow 저장값)")]
+    [SerializeField] private Vector3 _lineAPointA; // ObjectA 이동축 시작점
+    [SerializeField] private Vector3 _lineAPointB; // ObjectA 이동축 끝점
+    [SerializeField] private Vector3 _lineBPointA; // ObjectB 이동축 시작점
+    [SerializeField] private Vector3 _lineBPointB; // ObjectB 이동축 끝점
 
-    private SliderJoint _joint;             // SliderJoint.cs 인스턴스
-    private Vector3 _initialPosition;       // [2026.04.22 추가] 오브젝트 B 초기 위치 (SetPosition 기준점)
+    [Header("기준 Plane 좌표 (ConstraintAssemblyWindow 저장값)")]
+    [SerializeField] private Vector3 _planeAPointA; // ObjectA 기준 Plane 점 A
+    [SerializeField] private Vector3 _planeAPointB; // ObjectA 기준 Plane 점 B
+    [SerializeField] private Vector3 _planeAPointC; // ObjectA 기준 Plane 점 C
+    [SerializeField] private Vector3 _planeBPointA; // ObjectB 기준 Plane 점 A
+    [SerializeField] private Vector3 _planeBPointB; // ObjectB 기준 Plane 점 B
+    [SerializeField] private Vector3 _planeBPointC; // ObjectB 기준 Plane 점 C
 
-    public float CurrentPosition => _joint?.CurrentPosition ?? 0f;   // 현재 슬라이더 위치
-    public Vector3 MoveDirection => _moveDirection;                   // 슬라이더 이동 방향
+    // ============================================================
+    // 런타임 상태
+    // ============================================================
+
+    private SliderJoint _joint;
+    private Vector3 _initialPosition;      // Awake 시점 월드 좌표 (하위 호환용)
+    private Vector3 _localInitialPosition; // 부모 기준 로컬 초기 좌표 (셔틀 이동 추적용)
+
+    // ============================================================
+    // 프로퍼티
+    // ============================================================
+
+    public float CurrentPosition => _joint?.CurrentPosition ?? 0f;
+    public Vector3 MoveDirection => _moveDirection;
+
+    // ============================================================
+    // JointComponent 구현
+    // ============================================================
 
     /**
-     * @brief  이동 방향 벡터 정규화 후 SliderJoint 를 초기화한다.
+     * @brief  이동 방향 벡터를 정규화하고 SliderJoint 를 초기화한다.
+     *         부모 기준 로컬 좌표를 저장하여 셔틀 이동 후에도 기준점을 올바르게 유지한다.
      */
     protected override void InitializeChild()
     {
-        // 이동 방향 벡터 정규화 (GetProjectedDistance 거리 계산 및 위치 계산 정확도 보장)
         _moveDirection = _moveDirection.normalized;
 
-        // [2026.04.22 추가] 오브젝트 B 초기 위치 저장 (SetPosition 기준점)
         _initialPosition = _objectB.position;
+        _localInitialPosition = _objectB.parent != null
+            ? _objectB.parent.InverseTransformPoint(_objectB.position)
+            : _objectB.position;
 
-        InitializeJoint();
+        BuildJoint();
 
-        Debug.Log($"SliderJointComponent: 이동축이 {_moveDirection} 으로 설정되었습니다. \nInspector 에서도 설정된 이동축 확인이 가능합니다.");
+        Debug.Log($"[SliderJoint] 초기화 완료 | moveDirection={_moveDirection}");
     }
 
     /**
@@ -64,12 +86,11 @@ public class SliderJointComponent : JointComponent
      */
     protected override bool IsJointValid()
     {
-        if (_joint == null) return false;
-        return _joint.IsValid();
+        return _joint != null && _joint.IsValid();
     }
 
     /**
-     * @brief  SliderJoint 구속 조건 적용.
+     * @brief  SliderJoint 구속 조건을 적용한다.
      * @return bool  구속 중이면 true
      */
     protected override bool ApplyJointConstraint()
@@ -77,82 +98,81 @@ public class SliderJointComponent : JointComponent
         return _joint.ApplyConstraint();
     }
 
-    //TODO: 추후에 다시 확인 - 프리즈 대신 '구속 조건이 풀리면 → 다시 구속 위치로 이동' 구현 예정
-    //      현재는 구속 조건 확인을 위한 임시 프리즈 처리
     /**
-     * @brief  구속 상태일 때 슬라이더 위치를 제한한다.
-     *         범위를 벗어난 경우에만 클램프하여 강제 이동시키고,
-     *         범위 내에 있을 때는 _initialPosition 기준 현재 위치를 상태값에 반영한다.
-     *         SetPosition() 과 동일한 기준점(_initialPosition) 을 사용하여
-     *         _joint.CurrentPosition 누적 오차를 방지한다.
+     * @brief  구속 상태일 때 슬라이더 위치를 범위 내로 제한한다.
+     *         부모 로컬 좌표 기반으로 월드 기준점을 계산하여
+     *         셔틀 이동 후에도 올바른 위치를 유지한다.
+     *         범위를 벗어난 경우에만 클램프를 적용하고,
+     *         범위 내에 있을 때는 현재 위치를 상태값에 동기화한다.
      */
     protected override void OnConstrained()
     {
-        // [2026.04.22 수정] _initialPosition 기준으로 현재 위치 계산
-        // SetPosition() 과 동일한 기준점을 사용하여 _joint.CurrentPosition 일관성 유지
-        float currentPos = Vector3.Dot(_objectB.position - _initialPosition, _moveDirection);
+        Vector3 worldInitial = GetWorldInitial();
+        float currentPos = Vector3.Dot(_objectB.position - worldInitial, _moveDirection);
 
-        // 범위를 벗어났을 때만 클램프 적용
-        // 범위 내에 있을 때는 _currentPosition 을 직접 측정값으로 동기화하여 떨림 방지
         if (currentPos < _minPosition || currentPos > _maxPosition)
-        {
-            // [2026.04.22 수정] _initialPosition 기준으로 클램프 위치 계산 (SetPosition() 과 기준점 통일)
-            // [2026.04.22 수정] MovePosition → Transform 직접 제어
-            _objectB.position = _joint.GetClampedPosition(_objectB.position, _initialPosition, _moveDirection);
-        }
+            _objectB.position = _joint.GetClampedPosition(_objectB.position, worldInitial, _moveDirection);
         else
-        {
-            // 범위 내에 있을 때는 단순히 현재 위치를 상태값에 반영
             _joint.SetPosition(currentPos);
-        }
     }
 
     /**
-     * @brief  외부에서 슬라이더 위치를 설정한다.
-     *         ShuttleController.cs 에서 X·Y 바퀴 위치 제어 시 호출한다.
-     *         프레임 지연 없이 즉각적인 위치 제어를 수행한다.
-     * @param  position    설정할 슬라이더 위치 (m)
+     * @brief  Inspector 값 변경 시 SliderJoint 를 재초기화한다.
+     *         Play 모드에서는 실행되지 않는다.
+     */
+    protected override void OnValidateJoint()
+    {
+        BuildJoint();
+    }
+
+    // ============================================================
+    // 공개 메서드
+    // ============================================================
+
+    /**
+     * @brief  슬라이더 위치를 외부에서 직접 설정한다.
+     *         부모 로컬 좌표 기반으로 목표 월드 좌표를 계산하므로
+     *         셔틀이 X/Z 로 이동해도 기준점이 올바르게 유지된다.
+     * @param  position  설정할 슬라이더 위치 (m)
      */
     public void SetPosition(float position)
     {
         if (_joint == null) return;
 
-        // 로직 클래스의 상태값을 먼저 업데이트 (내부에서 min/max 클램프 처리됨)
         _joint.SetPosition(position);
 
-        // [2026.04.22 수정] _initialPosition 기준으로 목표 월드 좌표 계산
-        // OnConstrained() 와 동일한 기준점(_initialPosition) 을 사용하여
-        // _joint.CurrentPosition 누적 오차 방지
-        // [2026.04.22 수정] MovePosition → Transform 직접 제어
-        _objectB.position = _initialPosition + (_moveDirection.normalized * _joint.CurrentPosition);
+        _objectB.position = GetWorldInitial() + _moveDirection.normalized * _joint.CurrentPosition;
     }
 
-    /**
-     * @brief  Inspector 에서 값 변경 시 Line·Plane 을 재생성하고 SliderJoint 를 재초기화한다.
-     *         ※ Play 모드에서는 실행되지 않는다.
-     */
-    protected override void OnValidateJoint()
-    {
-        InitializeJoint();
-    }
+    // ============================================================
+    // 내부 메서드
+    // ============================================================
 
     /**
-     * @brief  Awake 및 OnValidate 에서 공통으로 호출되는 조인트 초기화 메서드.
-     *         이동축 Line 과 기준 Plane 을 생성하고 SliderJoint 인스턴스를 초기화한다.
+     * @brief  이동축 Line 과 기준 Plane 으로 SliderJoint 인스턴스를 생성한다.
+     *         InitializeChild() 와 OnValidateJoint() 에서 공통으로 호출한다.
      */
-    private void InitializeJoint()
+    private void BuildJoint()
     {
         if (_objectA == null || _objectB == null) return;
 
-        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
         Line lineA = new Line(_lineAPointA, _lineAPointB);
         Line lineB = new Line(_lineBPointA, _lineBPointB);
-
-        // [2026.04.22 수정] 저장된 점 좌표로 Plane 생성
         Plane planeA = new Plane(_planeAPointA, _planeAPointB, _planeAPointC);
         Plane planeB = new Plane(_planeBPointA, _planeBPointB, _planeBPointC);
 
-        // SliderJoint.cs 인스턴스 생성
         _joint = new SliderJoint(lineA, lineB, planeA, planeB, _minPosition, _maxPosition);
+    }
+
+    /**
+     * @brief  부모 기준 로컬 초기 좌표를 월드 좌표로 변환하여 반환한다.
+     *         부모가 없으면 로컬 좌표를 그대로 반환한다.
+     * @return Vector3  현재 프레임 기준 슬라이더 초기 월드 위치
+     */
+    private Vector3 GetWorldInitial()
+    {
+        return _objectB.parent != null
+            ? _objectB.parent.TransformPoint(_localInitialPosition)
+            : _localInitialPosition;
     }
 }

--- a/unity/Assets/Scripts/Controllers/SliderJointComponent.cs
+++ b/unity/Assets/Scripts/Controllers/SliderJointComponent.cs
@@ -3,7 +3,15 @@
 // 역할    : SliderJoint 를 씬 오브젝트에 연결하는 MonoBehaviour 컴포넌트
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - _lineAPointA/B, _lineBPointA/B 추가 (ConstraintAssemblyWindow 에서 저장)
+//                      - _planeAPointA/B/C, _planeBPointA/B/C 추가 (ConstraintAssemblyWindow 에서 저장)
+//                      - InitializeJoint() 에서 저장된 점 좌표로 Line, Plane 생성하도록 변경
+//                      - _initialPosition 추가 (SetPosition 기준점으로 사용)
+//                      - SetPosition() 에서 _objectA.position 대신 _initialPosition 사용
+//                      - OnConstrained() 기준점을 _initialPosition 으로 통일
+//                        (SetPosition() 과 기준점 불일치로 인한 위치 누적 오차 수정)
+//                      - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        (디지털 트윈 특성상 물리 엔진 불필요)
 // ============================================================
 
 using UnityEngine;
@@ -14,10 +22,25 @@ public class SliderJointComponent : JointComponent
     [SerializeField] private float _maxPosition = 100f;                  // 최대 이동 범위 - 오브젝트 A 위치 기준 절대값 (mm)
     [SerializeField] private Vector3 _moveDirection = Vector3.right;     // 슬라이더 이동 방향
 
-    private SliderJoint _joint;          // SliderJoint.cs 인스턴스
+    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 이동축 Line 점 좌표
+    [SerializeField] private Vector3 _lineAPointA;  // Object A 이동축 Line 시작점
+    [SerializeField] private Vector3 _lineAPointB;  // Object A 이동축 Line 끝점
+    [SerializeField] private Vector3 _lineBPointA;  // Object B 이동축 Line 시작점
+    [SerializeField] private Vector3 _lineBPointB;  // Object B 이동축 Line 끝점
+
+    // [2026.04.22 추가] ConstraintAssemblyWindow 에서 저장된 기준 Plane 점 좌표
+    [SerializeField] private Vector3 _planeAPointA;  // Object A 기준 Plane 점 A
+    [SerializeField] private Vector3 _planeAPointB;  // Object A 기준 Plane 점 B
+    [SerializeField] private Vector3 _planeAPointC;  // Object A 기준 Plane 점 C
+    [SerializeField] private Vector3 _planeBPointA;  // Object B 기준 Plane 점 A
+    [SerializeField] private Vector3 _planeBPointB;  // Object B 기준 Plane 점 B
+    [SerializeField] private Vector3 _planeBPointC;  // Object B 기준 Plane 점 C
+
+    private SliderJoint _joint;             // SliderJoint.cs 인스턴스
+    private Vector3 _initialPosition;       // [2026.04.22 추가] 오브젝트 B 초기 위치 (SetPosition 기준점)
 
     public float CurrentPosition => _joint?.CurrentPosition ?? 0f;   // 현재 슬라이더 위치
-    public Vector3 MoveDirection => _moveDirection;                  // 슬라이더 이동 방향
+    public Vector3 MoveDirection => _moveDirection;                   // 슬라이더 이동 방향
 
     /**
      * @brief  이동 방향 벡터 정규화 후 SliderJoint 를 초기화한다.
@@ -26,6 +49,9 @@ public class SliderJointComponent : JointComponent
     {
         // 이동 방향 벡터 정규화 (GetProjectedDistance 거리 계산 및 위치 계산 정확도 보장)
         _moveDirection = _moveDirection.normalized;
+
+        // [2026.04.22 추가] 오브젝트 B 초기 위치 저장 (SetPosition 기준점)
+        _initialPosition = _objectB.position;
 
         InitializeJoint();
 
@@ -39,7 +65,6 @@ public class SliderJointComponent : JointComponent
     protected override bool IsJointValid()
     {
         if (_joint == null) return false;
-
         return _joint.IsValid();
     }
 
@@ -57,19 +82,23 @@ public class SliderJointComponent : JointComponent
     /**
      * @brief  구속 상태일 때 슬라이더 위치를 제한한다.
      *         범위를 벗어난 경우에만 클램프하여 강제 이동시키고,
-     *         범위 내에 있을 때는 프리즈된 축 내에서 자유롭게 움직이도록 로직 상태만 동기화한다.
+     *         범위 내에 있을 때는 _initialPosition 기준 현재 위치를 상태값에 반영한다.
+     *         SetPosition() 과 동일한 기준점(_initialPosition) 을 사용하여
+     *         _joint.CurrentPosition 누적 오차를 방지한다.
      */
     protected override void OnConstrained()
     {
-        // 현재 물리적 위치에서의 거리를 로컬로 계산
-        float currentPos = Vector3.Dot(_objectB.position - _objectA.position, _moveDirection);
+        // [2026.04.22 수정] _initialPosition 기준으로 현재 위치 계산
+        // SetPosition() 과 동일한 기준점을 사용하여 _joint.CurrentPosition 일관성 유지
+        float currentPos = Vector3.Dot(_objectB.position - _initialPosition, _moveDirection);
 
         // 범위를 벗어났을 때만 클램프 적용
-        // 범위 내에 있을 때는 _currentPosition을 직접 측정값으로 동기화하여 떨림 방지
+        // 범위 내에 있을 때는 _currentPosition 을 직접 측정값으로 동기화하여 떨림 방지
         if (currentPos < _minPosition || currentPos > _maxPosition)
         {
-            Vector3 clampedPos = _joint.GetClampedPosition(_objectB.position, _objectA.position, _moveDirection);
-            _rigidbodyB.MovePosition(clampedPos);
+            // [2026.04.22 수정] _initialPosition 기준으로 클램프 위치 계산 (SetPosition() 과 기준점 통일)
+            // [2026.04.22 수정] MovePosition → Transform 직접 제어
+            _objectB.position = _joint.GetClampedPosition(_objectB.position, _initialPosition, _moveDirection);
         }
         else
         {
@@ -81,26 +110,21 @@ public class SliderJointComponent : JointComponent
     /**
      * @brief  외부에서 슬라이더 위치를 설정한다.
      *         ShuttleController.cs 에서 X·Y 바퀴 위치 제어 시 호출한다.
-     *         Rigidbody.MovePosition()과 Transform.position을 즉시 동기화하여
-     *         Update() → OnConstrained() 실행 시 타이밍 충돌을 방지하고
      *         프레임 지연 없이 즉각적인 위치 제어를 수행한다.
-     * @param  position    설정할 슬라이더 위치 (mm)
+     * @param  position    설정할 슬라이더 위치 (m)
      */
     public void SetPosition(float position)
     {
-        if (_joint == null || _rigidbodyB == null) return;
+        if (_joint == null) return;
 
         // 로직 클래스의 상태값을 먼저 업데이트 (내부에서 min/max 클램프 처리됨)
         _joint.SetPosition(position);
 
-        // 클램프된 결과값(_joint.CurrentPosition)을 바탕으로 목표 월드 좌표 계산
-        Vector3 targetWorldPos = _objectA.position + (_moveDirection.normalized * _joint.CurrentPosition);
-
-        // 물리 이동 명령 및 Transform 즉시 동기화
-        // Transform을 즉시 반영하여 다음 Update/FixedUpdate에서
-        // OnConstrained()가 이전 위치를 기준으로 재계산하는 문제를 방지
-        _rigidbodyB.MovePosition(targetWorldPos);
-        _objectB.position = targetWorldPos;
+        // [2026.04.22 수정] _initialPosition 기준으로 목표 월드 좌표 계산
+        // OnConstrained() 와 동일한 기준점(_initialPosition) 을 사용하여
+        // _joint.CurrentPosition 누적 오차 방지
+        // [2026.04.22 수정] MovePosition → Transform 직접 제어
+        _objectB.position = _initialPosition + (_moveDirection.normalized * _joint.CurrentPosition);
     }
 
     /**
@@ -120,48 +144,15 @@ public class SliderJointComponent : JointComponent
     {
         if (_objectA == null || _objectB == null) return;
 
-        // 오브젝트 A·B 의 Transform 에서 이동축 Line 생성
-        Line lineA = new Line(_objectA.position,
-                              _objectA.position + _moveDirection);
-        Line lineB = new Line(_objectB.position,
-                              _objectB.position + _moveDirection);
+        // [2026.04.22 수정] 저장된 점 좌표로 Line 생성
+        Line lineA = new Line(_lineAPointA, _lineAPointB);
+        Line lineB = new Line(_lineBPointA, _lineBPointB);
 
-        // 오브젝트 A·B 의 Transform 에서 기준 Plane 생성
-        // _objectA.right, _objectA.forward 로 면의 세 점 정의
-        Plane planeA = new Plane(_objectA.position,
-                                 _objectA.position + _objectA.right,
-                                 _objectA.position + _objectA.forward);
-        Plane planeB = new Plane(_objectB.position,
-                                 _objectB.position + _objectB.right,
-                                 _objectB.position + _objectB.forward);
+        // [2026.04.22 수정] 저장된 점 좌표로 Plane 생성
+        Plane planeA = new Plane(_planeAPointA, _planeAPointB, _planeAPointC);
+        Plane planeB = new Plane(_planeBPointA, _planeBPointB, _planeBPointC);
 
         // SliderJoint.cs 인스턴스 생성
-        _joint = new SliderJoint(lineA, lineB,
-                                 planeA, planeB,
-                                 _minPosition, _maxPosition);
-    }
-
-    /**
-     * @brief  슬라이더 이동 방향 축을 감지하여 해당 축만 열어두고
-     *         나머지 이동 및 회전을 프리즈한 RigidbodyConstraints 를 반환한다.
-     * @return RigidbodyConstraints  이동 방향 축만 열어둔 프리즈 조건
-     */
-    protected override RigidbodyConstraints GetFreezeConstraintByDirection()
-    {
-        // 이동 방향과 각 축의 유사도 계산
-        // Dot 결과값이 클수록 해당 축과 방향이 일치함을 의미
-        // ex) _moveDirection = (1,0,0) 이면 dotX = 1.0, dotY = 0.0, dotZ = 0.0
-        float dotX = Mathf.Abs(Vector3.Dot(_moveDirection, Vector3.right));
-        float dotY = Mathf.Abs(Vector3.Dot(_moveDirection, Vector3.up));
-        float dotZ = Mathf.Abs(Vector3.Dot(_moveDirection, Vector3.forward));
-
-        // 세 축 중 Dot 값이 가장 큰 축이 이동 방향 축
-        // 해당 축의 FreezePosition 만 제외하고 나머지는 전부 프리즈
-        if (dotX >= dotY && dotX >= dotZ)
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezePositionX;
-        else if (dotY >= dotX && dotY >= dotZ)
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezePositionY;
-        else
-            return RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezePositionZ;
+        _joint = new SliderJoint(lineA, lineB, planeA, planeB, _minPosition, _maxPosition);
     }
 }

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/DirectionSwitchController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/DirectionSwitchController.cs
@@ -1,0 +1,388 @@
+// ============================================================
+// 파일명  : DirectionSwitchController.cs
+// 역할    : 래크 앤 피니언 구동 시 슬라이더와 셔틀의 이동 주체를 전환한다.
+//
+//           [내려가는 방향] SpurGearController.IsForward = true
+//             Phase 1 (SliderMoving)  : 슬라이더 하강, 셔틀 고정
+//             Phase 2                 : ywheel3(슬라이더 바퀴) Y최저점이
+//                                       신호 시작 시 저장한 _targetFloorY 에 도달 → 전환
+//             Phase 3 (ShuttleMoving) : 셔틀 상승, 슬라이더 월드 위치 고정
+//
+//           [올라가는 방향] SpurGearController.IsForward = false
+//             Phase 1 (ShuttleMoving) : 셔틀 하강, 슬라이더 월드 위치 고정
+//             Phase 2                 : xwheel1(셔틀 바퀴) Y최저점이
+//                                       신호 시작 시 저장한 _targetFloorY 에 도달 → 전환
+//             Phase 3 (SliderMoving)  : 슬라이더 상승, 셔틀 고정
+//
+//           _targetFloorY:
+//             신호 시작 시 xwheel1 과 ywheel3 의 Y최저점 중 더 낮은 값을 저장한다.
+//             내려가는 방향: 슬라이더가 아직 내려가지 않았으므로 xwheel1.Y 가 낮음
+//                            → xwheel1.Y 가 트리거 기준이 됨
+//             올라가는 방향: 슬라이더가 이미 내려가 있으므로 ywheel3.Y 가 낮음
+//                            → ywheel3.Y 가 트리거 기준이 됨
+//             셔틀이 X/Z 이동 후에도 신호 시작 시 재계산되므로 위치 무관하게 동작한다.
+//
+//           슬라이더 고정:
+//             vslider1 은 셔틀의 자식이므로 셔틀 Y 이동 시 로컬 좌표로 함께 이동한다.
+//             ShuttleMoving 진입 시 슬라이더의 셔틀 기준 X/Z 로컬 오프셋과
+//             월드 Y 를 분리 저장하고, 매 프레임 셔틀 X/Z 위치 + 저장된 월드 Y 로
+//             복원하여 슬라이더를 고정한다.
+//
+// 작성자  : 이현화
+// 작성일  : 2026-04-27
+// ============================================================
+
+using UnityEngine;
+
+public class DirectionSwitchController : MonoBehaviour
+{
+    // ============================================================
+    // Inspector 필드
+    // ============================================================
+
+    [Header("필수 오브젝트")]
+    [SerializeField] private Transform _shuttle;           // 셔틀 최상위 Transform (Y축 이동 대상)
+    [SerializeField] private RackAndPinionController _rackAndPinion;     // deltaPosition 이벤트 소스
+    [SerializeField] private SliderJointComponent _vslider1Joint;     // vslider1 (ObjectB.position 접근용)
+    [SerializeField] private SpurGearController _spurGearController;// IsSignal, IsForward 참조
+
+    [Header("바퀴 메쉬")]
+    [SerializeField] private MeshFilter _xwheel1Mesh; // 셔틀 바퀴 MeshFilter (올라가는 방향 트리거 감지)
+    [SerializeField] private MeshFilter _ywheel3Mesh; // 슬라이더 바퀴 MeshFilter (내려가는 방향 트리거 감지)
+
+    [Header("파라미터")]
+    [SerializeField] private float _cooldownDuration = 0.5f;  // Phase 전환 후 재전환 방지 시간 (초)
+    [SerializeField] private float _returnTolerance = 0.002f;// 도달 판정 허용 오차 (m)
+
+    // ============================================================
+    // 상수
+    // ============================================================
+
+    private const float NoiseTolerance = 0.0001f; // deltaPosition 노이즈 필터 (m)
+
+    // ============================================================
+    // Phase 정의
+    // ============================================================
+
+    private enum Phase
+    {
+        SliderMoving,  // 슬라이더 이동 구간 (셔틀 고정)
+        ShuttleMoving  // 셔틀 이동 구간 (슬라이더 월드 위치 고정)
+    }
+
+    // ============================================================
+    // 런타임 상태
+    // ============================================================
+
+    private Phase _currentPhase;
+    private bool _isCooldown;
+    private float _cooldownTimer;
+
+    private float _targetFloorY;        // 신호 시작 시 저장한 트리거 기준 Y 최저점
+                                        // xwheel1 과 ywheel3 중 낮은 값으로 설정됨
+    private Vector3 _lockedSliderLocalXZ; // ShuttleMoving 진입 시 저장한 슬라이더의 셔틀 기준 로컬 X/Z
+    private float _lockedSliderWorldY;  // ShuttleMoving 진입 시 저장한 슬라이더의 월드 Y (고정 대상)
+    private bool _prevSignal;          // 이전 프레임 IsSignal — 신호 시작(false→true) 감지용
+
+    // ============================================================
+    // Unity 메시지
+    // ============================================================
+
+    private void Start()
+    {
+        if (!ValidateComponents()) return;
+        Initialize();
+    }
+
+    private void Update()
+    {
+        TickCooldown();
+        HandleSignalState();
+        DetectPhaseTransition();
+    }
+
+    private void OnDestroy()
+    {
+        if (_rackAndPinion != null)
+            _rackAndPinion.OnPositionChanged -= HandleRackMovement;
+    }
+
+    // ============================================================
+    // 초기화
+    // ============================================================
+
+    /**
+     * @brief  이벤트 구독 및 초기 Phase 를 설정한다.
+     *         내려가는 방향(IsForward=true)  → SliderMoving 으로 시작
+     *         올라가는 방향(IsForward=false) → ShuttleMoving 으로 시작,
+     *                                          슬라이더 월드 위치 즉시 저장
+     */
+    private void Initialize()
+    {
+        _isCooldown = false;
+        _cooldownTimer = 0f;
+
+        if (_spurGearController.IsForward)
+            _currentPhase = Phase.SliderMoving;
+        else
+        {
+            _currentPhase = Phase.ShuttleMoving;
+            LockSliderPosition();
+        }
+
+        _rackAndPinion.OnPositionChanged += HandleRackMovement;
+    }
+
+    // ============================================================
+    // 신호 처리
+    // ============================================================
+
+    /**
+     * @brief  IsSignal 의 false → true 전환(신호 시작)을 감지하여
+     *         _targetFloorY 와 Phase 를 현재 위치 기준으로 재초기화한다.
+     *
+     *         _targetFloorY 설정 원리:
+     *           내려가는 방향: 슬라이더가 아직 내려가지 않았으므로 xwheel1.Y < ywheel3.Y
+     *                          → _targetFloorY = xwheel1.Y (슬라이더가 도달해야 할 목표)
+     *           올라가는 방향: 슬라이더가 이미 내려가 있으므로 ywheel3.Y < xwheel1.Y
+     *                          → _targetFloorY = ywheel3.Y (셔틀이 복귀해야 할 목표)
+     *
+     *         쿨다운 중 신호 재입력은 직전 Phase 전환이 아직 진행 중임을 의미하므로
+     *         중복 신호로 판단하여 무시한다.
+     */
+    private void HandleSignalState()
+    {
+        bool currentSignal = _spurGearController.IsSignal;
+
+        if (!_prevSignal && currentSignal)
+        {
+            // 쿨다운 중이면 직전 Phase 전환이 아직 진행 중 → 중복 신호로 무시
+            if (_isCooldown)
+            {
+                Debug.LogWarning($"[DirectionSwitch] 신호 중복 감지 — 무시 | Phase={_currentPhase}");
+                _prevSignal = currentSignal;
+                return;
+            }
+
+            float xLow = GetMeshWorldYMin(_xwheel1Mesh);
+            float yLow = GetMeshWorldYMin(_ywheel3Mesh);
+
+            _targetFloorY = Mathf.Min(xLow, yLow);
+
+            if (_spurGearController.IsForward)
+                _currentPhase = Phase.SliderMoving;
+            else
+            {
+                _currentPhase = Phase.ShuttleMoving;
+                LockSliderPosition();
+            }
+
+            Debug.Log($"[DirectionSwitch] 신호 시작 | Phase={_currentPhase} targetFloorY={_targetFloorY:F4} (xLow={xLow:F4} yLow={yLow:F4})");
+        }
+
+        _prevSignal = currentSignal;
+    }
+
+    // ============================================================
+    // Phase 전환 감지
+    // ============================================================
+
+    /**
+     * @brief  매 프레임 Phase 전환 조건을 감지한다.
+     *         IsSignal=true 이고 쿨다운이 해제된 경우에만 실행한다.
+     */
+    private void DetectPhaseTransition()
+    {
+        if (!_spurGearController.IsSignal || _isCooldown) return;
+
+        if (_spurGearController.IsForward)
+            CheckSliderReachedFloor();
+        else
+            CheckShuttleReachedFloor();
+    }
+
+    /**
+     * @brief  내려가는 방향 전환 감지.
+     *         ywheel3(슬라이더 바퀴) Y최저점이 _targetFloorY 에 도달하면
+     *         SliderMoving → ShuttleMoving 으로 전환한다.
+     *         슬라이더 바퀴가 셔틀 바퀴 높이까지 내려왔음을 의미한다.
+     */
+    private void CheckSliderReachedFloor()
+    {
+        if (_currentPhase != Phase.SliderMoving) return;
+
+        float currentSliderY = GetMeshWorldYMin(_ywheel3Mesh);
+
+        if (currentSliderY <= _targetFloorY + _returnTolerance)
+        {
+            _currentPhase = Phase.ShuttleMoving;
+            LockSliderPosition();
+            StartCooldown();
+            Debug.Log($"[DirectionSwitch] Slider → Shuttle | 현재 높이={currentSliderY:F4}, 목표 바닥={_targetFloorY:F4}");
+        }
+    }
+
+    /**
+     * @brief  올라가는 방향 전환 감지.
+     *         xwheel1(셔틀 바퀴) Y최저점이 _targetFloorY 에 도달하면
+     *         ShuttleMoving → SliderMoving 으로 전환한다.
+     *         셔틀 바퀴가 슬라이더 바퀴 높이까지 내려왔음을 의미한다.
+     */
+    private void CheckShuttleReachedFloor()
+    {
+        if (_currentPhase != Phase.ShuttleMoving) return;
+
+        float currentShuttleY = GetMeshWorldYMin(_xwheel1Mesh);
+
+        if (currentShuttleY <= _targetFloorY + _returnTolerance)
+        {
+            _currentPhase = Phase.SliderMoving;
+            StartCooldown();
+            Debug.Log($"[DirectionSwitch] Shuttle → Slider | 현재 높이={currentShuttleY:F4}, 목표 바닥={_targetFloorY:F4}");
+        }
+    }
+
+    // ============================================================
+    // 이동 처리
+    // ============================================================
+
+    /**
+     * @brief  RackAndPinionController 의 deltaPosition 이벤트 핸들러.
+     *         ShuttleMoving Phase 에서만 셔틀 이동 + 슬라이더 위치 고정을 수행한다.
+     *         SliderMoving Phase 에서는 RackAndPinionController 가 슬라이더를 처리 → 무처리.
+     * @param  deltaPosition  래크 이동량 (m)
+     */
+    private void HandleRackMovement(float deltaPosition)
+    {
+        if (Mathf.Abs(deltaPosition) < NoiseTolerance) return;
+
+        if (_currentPhase == Phase.ShuttleMoving)
+            MoveShuttleAndLockSlider(deltaPosition);
+    }
+
+    /**
+     * @brief  셔틀을 deltaPosition 반대 방향으로 이동시키고
+     *         슬라이더를 셔틀 기준 로컬 X/Z + 저장된 월드 Y 로 강제 복원한다.
+     *
+     *         셔틀 Y 이동 시: 슬라이더 Y 는 _lockedSliderWorldY 로 고정되어 변하지 않음
+     *         셔틀 X/Z 이동 시: _lockedSliderLocalXZ 를 현재 셔틀 기준으로 변환하므로
+     *                            슬라이더가 셔틀과 함께 따라옴
+     *
+     *         내려가는 방향(Phase 3): deltaPosition < 0 → 셔틀 상승
+     *         올라가는 방향(Phase 1): deltaPosition > 0 → 셔틀 하강
+     *
+     * @param  deltaPosition  래크 이동량 (m)
+     */
+    private void MoveShuttleAndLockSlider(float deltaPosition)
+    {
+        _shuttle.position += Vector3.up * -deltaPosition;
+
+        // 셔틀 기준 로컬 X/Z → 현재 셔틀 위치 기준 월드 X/Z 로 변환
+        // Y 는 저장된 월드 Y 로 고정하여 셔틀 Y 이동이 슬라이더에 전파되지 않도록 함
+        Vector3 shuttleWorldXZ = _shuttle.TransformPoint(_lockedSliderLocalXZ);
+        _vslider1Joint.ObjectB.position = new Vector3(shuttleWorldXZ.x, _lockedSliderWorldY, shuttleWorldXZ.z);
+    }
+
+    /**
+     * @brief  슬라이더 위치를 셔틀 기준 로컬 X/Z 오프셋과 월드 Y 로 분리하여 저장한다.
+     *         ShuttleMoving 진입 시 및 올라가는 방향 신호 시작 시 호출한다.
+     *         Y 성분을 월드 좌표로 별도 저장하여 셔틀 Y 이동 시 슬라이더가
+     *         함께 올라가는 문제를 방지한다.
+     */
+    private void LockSliderPosition()
+    {
+        Vector3 sliderWorldPos = _vslider1Joint.ObjectB.position;
+        Vector3 sliderLocalPos = _shuttle.InverseTransformPoint(sliderWorldPos);
+
+        // X/Z 로컬 오프셋 저장 (셔틀 X/Z 이동 추적용, Y 는 0 으로 제외)
+        _lockedSliderLocalXZ = new Vector3(sliderLocalPos.x, 0f, sliderLocalPos.z);
+
+        // 월드 Y 별도 저장 (셔틀 Y 이동과 무관하게 고정)
+        _lockedSliderWorldY = sliderWorldPos.y;
+    }
+
+    // ============================================================
+    // 쿨다운
+    // ============================================================
+
+    /**
+     * @brief  Phase 전환 후 쿨다운 타이머를 감산한다.
+     *         타이머가 0 이하가 되면 쿨다운을 해제한다.
+     */
+    private void TickCooldown()
+    {
+        if (!_isCooldown) return;
+
+        _cooldownTimer -= Time.deltaTime;
+        if (_cooldownTimer <= 0f)
+        {
+            _isCooldown = false;
+            _cooldownTimer = 0f;
+        }
+    }
+
+    /**
+     * @brief  쿨다운을 시작한다.
+     */
+    private void StartCooldown()
+    {
+        _isCooldown = true;
+        _cooldownTimer = _cooldownDuration;
+    }
+
+    // ============================================================
+    // 유틸리티
+    // ============================================================
+
+    /**
+     * @brief  MeshFilter.sharedMesh.bounds 를 이용하여 월드 기준 Y 최솟값을 반환한다.
+     *         Renderer.bounds(AABB) 는 바퀴 회전 시 크기가 변하여 오차가 발생하므로
+     *         sharedMesh.bounds 기준으로 로컬 최저점을 계산하고 월드 좌표로 변환한다.
+     * @param  meshFilter  대상 MeshFilter
+     * @return float       월드 기준 Y 최솟값
+     */
+    private float GetMeshWorldYMin(MeshFilter meshFilter)
+    {
+        Bounds bounds = meshFilter.sharedMesh.bounds;
+        Vector3 localLowest = bounds.center - new Vector3(0f, bounds.extents.y, 0f);
+        return meshFilter.transform.TransformPoint(localLowest).y;
+    }
+
+    // ============================================================
+    // 유효성 검사
+    // ============================================================
+
+    /**
+     * @brief  Inspector 할당 필수 오브젝트의 유효성을 검사한다.
+     *         하나라도 미할당 시 컴포넌트를 비활성화하고 false 를 반환한다.
+     * @return bool  모두 유효하면 true
+     */
+    private bool ValidateComponents()
+    {
+        bool isValid = true;
+
+        isValid &= AssertNotNull(_shuttle, nameof(_shuttle));
+        isValid &= AssertNotNull(_rackAndPinion, nameof(_rackAndPinion));
+        isValid &= AssertNotNull(_vslider1Joint, nameof(_vslider1Joint));
+        isValid &= AssertNotNull(_spurGearController, nameof(_spurGearController));
+        isValid &= AssertNotNull(_xwheel1Mesh, nameof(_xwheel1Mesh));
+        isValid &= AssertNotNull(_ywheel3Mesh, nameof(_ywheel3Mesh));
+
+        if (!isValid) enabled = false;
+        return isValid;
+    }
+
+    /**
+     * @brief  오브젝트가 null 이면 에러 로그를 출력하고 false 를 반환한다.
+     * @param  obj   검사할 오브젝트
+     * @param  name  필드명 (로그 출력용)
+     * @return bool  null 이 아니면 true
+     */
+    private bool AssertNotNull(Object obj, string name)
+    {
+        if (obj != null) return true;
+
+        Debug.LogError($"[DirectionSwitch] {name}이(가) 할당되지 않았습니다.");
+        return false;
+    }
+}

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/DirectionSwitchController.cs.meta
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/DirectionSwitchController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26e66333fecee0c4d92356efde9681d7

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs
@@ -2,76 +2,93 @@
 // 파일명  : RackAndPinionController.cs
 // 역할    : RevoluteJoint 회전 각도를 SliderJoint 이동 거리로 변환한다.
 //           랙 앤 피니언 수식: 이동 거리 = 기어 반지름 × 회전 각도(rad)
+//           변환된 deltaPosition 을 OnPositionChanged 이벤트로 발행한다.
+//           DirectionSwitchController 가 이를 구독하여 Phase 에 따라
+//           셔틀 이동 또는 슬라이더 고정을 처리한다.
+//
 // 작성자  : 이현화
-// 작성일  : 2026-04-22
+// 작성일  : 2026-04-27
+// 수정이력: 
 // ============================================================
 
 using UnityEngine;
 
 public class RackAndPinionController : MonoBehaviour
 {
-    [SerializeField] private RevoluteJointComponent _revoluteJoint;  // spurgear1 회전 조인트
-    [SerializeField] private SliderJointComponent _sliderJoint;      // vslider1 슬라이더 조인트
-    [SerializeField] private float _gearRadius = 0.055f;             // 기어 반지름 (m)
-    [SerializeField] private float _motionDirection = -1f;           // 기어-랙 맞물림 방향 (1 또는 -1)
-                                                                     // 기어와 랙의 맞물리는 면에 따라 결정되는 설계 정보
-                                                                     // Inspector 에서 직접 설정
+    // ============================================================
+    // Inspector 필드
+    // ============================================================
 
-    private float _lastAngle = 0f;  // 이전 프레임 각도 (delta 계산용)
+    [Header("필수 오브젝트")]
+    [SerializeField] private RevoluteJointComponent _revoluteJoint; // spurgear1 회전 조인트
+    [SerializeField] private SliderJointComponent _sliderJoint;   // vslider1 슬라이더 조인트
+
+    [Header("파라미터")]
+    [SerializeField] private float _gearRadius = 0.055f; // 기어 반지름 (m)
+    [SerializeField] private float _motionDirection = -1f;    // 기어-랙 맞물림 방향 (1 또는 -1)
+
+    // ============================================================
+    // 상수
+    // ============================================================
+
+    private const float NoiseThreshold = 0.1f;    // 노이즈로 간주할 최대 각도 변화량 (rad)
+    private const float MinDeltaPosition = 0.0001f; // 이벤트 발행 최소 이동량 (m)
+
+    // ============================================================
+    // 이벤트
+    // ============================================================
+
+    /// deltaPosition 계산 후 발행되는 이벤트.
+    /// DirectionSwitchController 가 구독하여 Phase 에 따라 셔틀 이동 또는 슬라이더 고정을 처리한다.
+    public System.Action<float> OnPositionChanged;
+
+    // ============================================================
+    // 런타임 상태
+    // ============================================================
+
+    private float _lastAngle; // 이전 프레임 회전 각도
+
+    // ============================================================
+    // Unity 메시지
+    // ============================================================
 
     private void Start()
     {
         _lastAngle = _revoluteJoint.CurrentAngle;
 
-        // 클램프 시 _lastAngle 동기화 (순간이동 방지)
-        _revoluteJoint.OnClampedCallback += (clampedRot) =>
-        {
-            _lastAngle = _revoluteJoint.CurrentAngle;
-        };
+        _revoluteJoint.OnClampedCallback += _ => _lastAngle = _revoluteJoint.CurrentAngle;
     }
 
     /**
-     * @brief  매 프레임 RevoluteJoint 의 현재 각도와 이전 각도의 차이(delta)를 계산하여
-     *         SliderJoint 의 이동 거리로 변환하여 적용한다.
-     *         전체 각도가 아닌 delta 를 사용하는 이유:
-     *         클램프 시 각도가 순간적으로 크게 변하는 것을 방지하기 위함
-     *         delta 가 0.1f(rad) 초과이면 순간이동으로 판단하여 무시하고,
-     *         deltaPosition 이 0.0001f 미만이면 각도 계산 노이즈로 판단하여 SetPosition() 호출을 생략한다.
-     *         _motionDirection 으로 기어-랙 맞물림 방향을 보정한다.
+     * @brief  매 프레임 회전 각도 변화량을 이동 거리로 변환하고
+     *         SliderJoint 위치를 업데이트한 뒤 OnPositionChanged 이벤트를 발행한다.
+     *         노이즈(0.1 rad 초과) 또는 최소 이동량(0.0001 m) 미만이면 무시한다.
      */
     private void Update()
     {
         if (_revoluteJoint == null || _sliderJoint == null) return;
 
-        // 현재 각도와 이전 각도의 차이(delta) 계산
         float currentAngle = _revoluteJoint.CurrentAngle;
         float deltaAngleRad = (currentAngle - _lastAngle) * Mathf.Deg2Rad;
 
-        // delta가 너무 크면 순간이동으로 판단하고 무시
-        // _lastAngle 을 갱신하지 않아야 다음 프레임에서 누락된 delta 를 이어받을 수 있음
-        if (Mathf.Abs(deltaAngleRad) > 0.1f)
-        {
-            return;  // _lastAngle 갱신 없이 return
-        }
+        if (Mathf.Abs(deltaAngleRad) > NoiseThreshold) return;
 
-        // 랙 앤 피니언 수식: 이동 거리 = 기어 반지름 × 회전 각도(rad)
-        // _motionDirection: 기어와 랙의 맞물리는 면에 따라 결정되는 방향 보정값 (1 또는 -1)
         float deltaPosition = _motionDirection * _gearRadius * deltaAngleRad;
 
-        // delta가 너무 작으면 각도 계산 노이즈로 판단하고 SetPosition() 호출 생략
-        // 이유: _objectBRotationAxis 미세 흔들림으로 인해 currentAngle 이 매 프레임
-        //       조금씩 변하는 현상이 있어, 그 오차가 누적되어 vslider1 이 서서히
-        //       이동하는 문제를 방지하기 위함
-        if (Mathf.Abs(deltaPosition) < 0.0001f)
+        if (Mathf.Abs(deltaPosition) < MinDeltaPosition)
         {
             _lastAngle = currentAngle;
             return;
         }
 
-        // SliderJoint 에 현재 위치 + delta 이동 거리 적용
         _sliderJoint.SetPosition(_sliderJoint.CurrentPosition + deltaPosition);
 
-        // 이전 프레임 각도 업데이트
+        Debug.Log($"[RackAndPinion] currentPos={_sliderJoint.CurrentPosition:F4}");
+
+        // SliderMoving Phase : 슬라이더가 실제로 이동함
+        // ShuttleMoving Phase: DirectionSwitchController 가 Transform 강제 복원으로 슬라이더를 고정함
+        OnPositionChanged?.Invoke(deltaPosition);
+
         _lastAngle = currentAngle;
     }
 }

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs
@@ -1,0 +1,77 @@
+// ============================================================
+// 파일명  : RackAndPinionController.cs
+// 역할    : RevoluteJoint 회전 각도를 SliderJoint 이동 거리로 변환한다.
+//           랙 앤 피니언 수식: 이동 거리 = 기어 반지름 × 회전 각도(rad)
+// 작성자  : 이현화
+// 작성일  : 2026-04-22
+// ============================================================
+
+using UnityEngine;
+
+public class RackAndPinionController : MonoBehaviour
+{
+    [SerializeField] private RevoluteJointComponent _revoluteJoint;  // spurgear1 회전 조인트
+    [SerializeField] private SliderJointComponent _sliderJoint;      // vslider1 슬라이더 조인트
+    [SerializeField] private float _gearRadius = 0.055f;             // 기어 반지름 (m)
+    [SerializeField] private float _motionDirection = -1f;           // 기어-랙 맞물림 방향 (1 또는 -1)
+                                                                     // 기어와 랙의 맞물리는 면에 따라 결정되는 설계 정보
+                                                                     // Inspector 에서 직접 설정
+
+    private float _lastAngle = 0f;  // 이전 프레임 각도 (delta 계산용)
+
+    private void Start()
+    {
+        _lastAngle = _revoluteJoint.CurrentAngle;
+
+        // 클램프 시 _lastAngle 동기화 (순간이동 방지)
+        _revoluteJoint.OnClampedCallback += (clampedRot) =>
+        {
+            _lastAngle = _revoluteJoint.CurrentAngle;
+        };
+    }
+
+    /**
+     * @brief  매 프레임 RevoluteJoint 의 현재 각도와 이전 각도의 차이(delta)를 계산하여
+     *         SliderJoint 의 이동 거리로 변환하여 적용한다.
+     *         전체 각도가 아닌 delta 를 사용하는 이유:
+     *         클램프 시 각도가 순간적으로 크게 변하는 것을 방지하기 위함
+     *         delta 가 0.1f(rad) 초과이면 순간이동으로 판단하여 무시하고,
+     *         deltaPosition 이 0.0001f 미만이면 각도 계산 노이즈로 판단하여 SetPosition() 호출을 생략한다.
+     *         _motionDirection 으로 기어-랙 맞물림 방향을 보정한다.
+     */
+    private void Update()
+    {
+        if (_revoluteJoint == null || _sliderJoint == null) return;
+
+        // 현재 각도와 이전 각도의 차이(delta) 계산
+        float currentAngle = _revoluteJoint.CurrentAngle;
+        float deltaAngleRad = (currentAngle - _lastAngle) * Mathf.Deg2Rad;
+
+        // delta가 너무 크면 순간이동으로 판단하고 무시
+        // _lastAngle 을 갱신하지 않아야 다음 프레임에서 누락된 delta 를 이어받을 수 있음
+        if (Mathf.Abs(deltaAngleRad) > 0.1f)
+        {
+            return;  // _lastAngle 갱신 없이 return
+        }
+
+        // 랙 앤 피니언 수식: 이동 거리 = 기어 반지름 × 회전 각도(rad)
+        // _motionDirection: 기어와 랙의 맞물리는 면에 따라 결정되는 방향 보정값 (1 또는 -1)
+        float deltaPosition = _motionDirection * _gearRadius * deltaAngleRad;
+
+        // delta가 너무 작으면 각도 계산 노이즈로 판단하고 SetPosition() 호출 생략
+        // 이유: _objectBRotationAxis 미세 흔들림으로 인해 currentAngle 이 매 프레임
+        //       조금씩 변하는 현상이 있어, 그 오차가 누적되어 vslider1 이 서서히
+        //       이동하는 문제를 방지하기 위함
+        if (Mathf.Abs(deltaPosition) < 0.0001f)
+        {
+            _lastAngle = currentAngle;
+            return;
+        }
+
+        // SliderJoint 에 현재 위치 + delta 이동 거리 적용
+        _sliderJoint.SetPosition(_sliderJoint.CurrentPosition + deltaPosition);
+
+        // 이전 프레임 각도 업데이트
+        _lastAngle = currentAngle;
+    }
+}

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs.meta
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/RackAndPinionController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53b5e41bcc6b43c429dfd4bced981886

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/RevoluteFreezeTestManager.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/RevoluteFreezeTestManager.cs
@@ -4,44 +4,65 @@
 //           마우스 드래그로 오브젝트 B에 회전을 주어 구속 조건 및 클램프를 테스트한다.
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - LineBCenter 기반 위치 보정 추가 (_centerPoint, _centerOffset)
+//                      - _fixedRotation 추가 (누적 회전값)
+//                      - OnClampedCallback 등록 (클램프 후 offset, rotation 동기화)
+//                      - Update() @brief 주석 수정 (목표 위치 저장 내용 추가)
+//                      - FixedUpdate() → Update() 로 변경, Rigidbody 제거
+//                        (Transform 직접 제어 방식으로 리팩토링)
 // ============================================================
 
 using UnityEngine;
 
 public class RevoluteFreezeTestManager : MonoBehaviour
 {
+    // Inspector 연결 필드
     [SerializeField] private Transform _objectB;                        // 테스트 대상 오브젝트 B 연결
     [SerializeField] private RevoluteJointComponent _jointComponent;    // 회전축 참조용 컴포넌트
     [SerializeField] private float _rotateSpeed = 10f;                  // 마우스 드래그 감도
     [SerializeField] private bool _useMouseY = true;                    // 마우스 입력 방향 (true: 위아래, false: 좌우)
 
-    private Rigidbody _rigidbodyB;          // 오브젝트 B 리지드바디
-    private Quaternion _pendingRotation;    // 목표 회전값 임시 저장 (Update → FixedUpdate 전달용)
-    private bool _hasPending;               // 이번 프레임에 입력이 있었는지 여부
+    // 런타임 필드
+    private Vector3 _centerPoint;           // [2026.04.22 추가] lineB 시작점 (위치 보정 기준)
+    private Vector3 _centerOffset;          // [2026.04.22 추가] 중심점과 오브젝트 B position 의 차이
+    private Quaternion _fixedRotation;      // [2026.04.22 추가] 누적 회전값
 
     private void Start()
     {
-        // 오브젝트 B 의 Rigidbody 컴포넌트를 가져온다.
-        _rigidbodyB = _objectB.GetComponent<Rigidbody>();
-
-        // Rigidbody 가 없으면 경고 출력
-        if (_rigidbodyB == null)
+        if (_objectB == null)
         {
             Debug.LogWarning("RevoluteFreezeTestManager: 움직일 오브젝트(Object B)가 연결되지 않았습니다. \nInspector 에서 오브젝트를 연결해주세요.");
+            return;
         }
+
+        if (_jointComponent == null)
+        {
+            Debug.LogWarning("RevoluteFreezeTestManager: JointComponent 가 연결되지 않았습니다. \nInspector 에서 오브젝트를 연결해주세요.");
+            return;
+        }
+
+        // [2026.04.22 추가] 중심점, offset, 초기 회전값 한 번만 계산
+        _centerPoint = _jointComponent.LineBCenter;
+        _centerOffset = _objectB.position - _centerPoint;
+        _fixedRotation = _objectB.rotation;
+
+        // [2026.04.22 추가] 클램프 후 offset, rotation 동기화 콜백 등록
+        _jointComponent.OnClampedCallback = (clampedRot) =>
+        {
+            Quaternion delta = clampedRot * Quaternion.Inverse(_fixedRotation);
+            _centerOffset = delta * _centerOffset;
+            _fixedRotation = clampedRot;
+        };
     }
 
     /**
-     * @brief  마우스 오른쪽 버튼을 누르고 드래그하면 목표 회전값을 _pendingRotation 에 저장한다.
-     *         마우스 입력은 Update 에서만 읽어야 하므로 물리 적용은 FixedUpdate 에 위임한다.
+     * @brief  마우스 오른쪽 버튼을 누르고 드래그하면 목표 회전값과 위치를 계산하여
+     *         Transform 직접 제어로 즉시 적용한다.
      */
     private void Update()
     {
-        // Rigidbody 가 없으면 이하 코드 실행하지 않는다.
-        if (_rigidbodyB == null) return;
+        if (_objectB == null) return;
 
-        // JointComponent 가 없으면 이하 코드 실행하지 않는다.
         if (_jointComponent == null)
         {
             Debug.LogWarning("RevoluteFreezeTestManager: JointComponent 가 연결되지 않았습니다. \nInspector 에서 오브젝트를 연결해주세요.");
@@ -54,31 +75,20 @@ public class RevoluteFreezeTestManager : MonoBehaviour
             float delta = Input.GetAxis(_useMouseY ? "Mouse Y" : "Mouse X") *
                 _rotateSpeed * Time.deltaTime;
 
-            // 회전축 가져오기
+            // lineB.Direction 기준 회전축
             Vector3 rotationAxis = _jointComponent.ObjectBRotationAxis;
 
             // 회전 변화량을 Quaternion 으로 변환
             Quaternion rotation = Quaternion.AngleAxis(delta, rotationAxis);
 
-            // 목표 회전값 계산 후 저장 (물리 적용은 FixedUpdate 에 위임)
-            _pendingRotation = rotation * _rigidbodyB.rotation;
-            _hasPending = true;
-        }
-        else
-        {
-            _hasPending = false;  // 버튼 안 누르면 초기화
-        }
-    }
+            // [2026.04.22 수정] Transform 직접 제어로 즉시 적용
+            // offset 을 회전시켜 중심점 기준 위치 보정
+            _centerOffset = rotation * _centerOffset;
+            _objectB.position = _centerPoint + _centerOffset;  // 위치 즉시 적용
 
-    /**
-     * @brief  매 물리 프레임 _pendingRotation 을 읽어 오브젝트 B 를 회전시킨다.
-     *         Rigidbody.MoveRotation() 은 물리 연산이므로 FixedUpdate 에서 호출한다.
-     */
-    private void FixedUpdate()
-    {
-        // 입력값이 없으면 실행하지 않는다.
-        if (_rigidbodyB == null || !_hasPending) return;
-
-        _rigidbodyB.MoveRotation(_pendingRotation);
+            // 누적 회전값 업데이트 후 즉시 적용
+            _fixedRotation = rotation * _fixedRotation;
+            _objectB.rotation = _fixedRotation;  // 회전 즉시 적용
+        }
     }
 }

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/SliderFreezeTestManager.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/SliderFreezeTestManager.cs
@@ -4,7 +4,8 @@
 //           마우스 드래그로 오브젝트 B 를 이동시켜 구속 조건 및 클램프를 테스트한다.
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - FixedUpdate() → Update() 로 변경, Rigidbody 제거
+//                        (Transform 직접 제어 방식으로 리팩토링)
 // ============================================================
 
 using UnityEngine;
@@ -14,60 +15,31 @@ public class SliderFreezeTestManager : MonoBehaviour
     [SerializeField] private Transform _objectB;         // 테스트 대상 오브젝트 B 연결
     [SerializeField] private float _sliderSpeed = 10f;  // 마우스 드래그 감도
 
-    private Rigidbody _rigidbodyB;      // 오브젝트 B 리지드바디
-    private Vector3 _pendingPosition;   // 목표 위치 임시 저장 (Update → FixedUpdate 전달용)
-    private bool _hasPending;           // 이번 프레임에 입력이 있었는지 여부
-
     private void Start()
     {
-        // 오브젝트 B 의 Rigidbody 컴포넌트를 가져온다.
-        _rigidbodyB = _objectB.GetComponent<Rigidbody>();
-
-        // Rigidbody 가 없으면 경고 출력 후 종료
-        if (_rigidbodyB == null)
+        if (_objectB == null)
         {
             Debug.LogWarning("SliderFreezeTestManager: 움직일 오브젝트(Object B)가 연결되지 않았습니다. \nInspector 에서 오브젝트를 연결해주세요.");
-            return;
         }
-        
     }
 
     /**
-     * @brief  마우스 왼쪽 버튼을 누르고 드래그하면 목표 위치를 _pendingPosition 에 저장한다.
-     *         마우스 입력은 Update 에서만 읽어야 하므로 물리 적용은 FixedUpdate 에 위임한다.
+     * @brief  마우스 왼쪽 버튼을 누르고 드래그하면 목표 위치를 계산하여
+     *         Transform 직접 제어로 즉시 적용한다.
      */
     private void Update()
     {
-        // Rigidbody 가 없으면 이하 코드 실행하지 않는다.
-        if (_rigidbodyB == null) return;
+        if (_objectB == null) return;
 
         if (Input.GetMouseButton(0))
         {
+            // 마우스 위치를 월드 좌표로 변환
             Vector3 mousePos = Input.mousePosition;
-            mousePos.z = Camera.main.WorldToScreenPoint(_rigidbodyB.transform.position).z;
+            mousePos.z = Camera.main.WorldToScreenPoint(_objectB.position).z;
             Vector3 worldPos = Camera.main.ScreenToWorldPoint(mousePos);
 
-            // 목표 위치 계산 후 저장 (물리 적용은 FixedUpdate 에 위임)
-            _pendingPosition = _rigidbodyB.position + (worldPos - _rigidbodyB.position) * _sliderSpeed * Time.deltaTime;
-            _hasPending = true;
+            // [2026.04.22 수정] Transform 직접 제어로 즉시 적용
+            _objectB.position += (worldPos - _objectB.position) * _sliderSpeed * Time.deltaTime;
         }
-        else
-        {
-            _hasPending = false;  // 버튼 안 누르면 초기화
-        }
-
-    }
-
-    /**
-    * @brief  매 물리 프레임 _pendingPosition 을 읽어 오브젝트 B 를 이동시킨다.
-    *         Rigidbody.MovePosition() 은 물리 연산이므로 FixedUpdate 에서 호출한다.
-    */
-    private void FixedUpdate()
-    {
-        // 입력값이 없으면 실행하지 않는다.
-        if (_rigidbodyB == null || !_hasPending) return;
-
-        _rigidbodyB.angularVelocity = Vector3.zero;  // 회전 속도 초기화
-        _rigidbodyB.MovePosition(_pendingPosition);
     }
 }

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/SpurGearController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/SpurGearController.cs
@@ -1,0 +1,165 @@
+// ============================================================
+// 파일명  : SpurGearController.cs
+// 역할    : spurgear1 을 회전시킨다.
+//           3초에 1바퀴 기준으로 _duration 초 동안 동작한다.
+//           SetAngle() 을 통해 클램프를 포함한 회전을 적용한다.
+//           LineBCenter 기준 position 보정으로 자전을 구현한다.
+//           IsSignal 로 DirectionSwitchController 의 Phase 전환 감지를 활성화한다.
+//           IsForward 로 현재 이동 방향을 외부에 노출한다.
+//             true : 내려가는 방향 (슬라이더 먼저 내려감)
+//             false: 올라가는 방향 (셔틀 먼저 내려감)
+//
+// 작성자  : 이현화
+// 작성일  : 2026-04-27
+// 수정이력: 
+// ============================================================
+
+using UnityEngine;
+
+public class SpurGearController : MonoBehaviour
+{
+    // ============================================================
+    // Inspector 필드
+    // ============================================================
+
+    [Header("필수 오브젝트")]
+    [SerializeField] private Transform _shuttle;        // 셔틀 최상위 Transform (이동량 계산용)
+    [SerializeField] private RevoluteJointComponent _spurGear1Joint; // spurgear1 조인트
+
+    [Header("파라미터")]
+    [SerializeField] private float _duration = 0f;   // 회전 지속 시간 (초) — 3초당 1바퀴 기준
+    [SerializeField] private bool _isSignal = false; // 동작 신호 (true 시 회전 시작)
+    [SerializeField] private bool _isForward = true;  // 이동 방향
+                                                      // true : 내려가는 방향 (슬라이더 먼저 내려감)
+                                                      // false: 올라가는 방향 (셔틀 먼저 내려감)
+
+    // ============================================================
+    // 상수
+    // ============================================================
+
+    private const float SecondsPerRotation = 3f;                           // 1바퀴당 기준 시간 (초)
+    private const float DegreesPerSecond = 360f / SecondsPerRotation;   // 초당 회전 각도
+
+    // ============================================================
+    // 프로퍼티
+    // ============================================================
+
+    /// DirectionSwitchController 에서 Phase 전환 감지 활성화 여부 확인용
+    public bool IsSignal => _isSignal;
+
+    /// DirectionSwitchController 에서 방향 분기 시 사용
+    public bool IsForward => _isForward;
+
+    // ============================================================
+    // 런타임 상태
+    // ============================================================
+
+    private float _elapsedTime;    // 경과 시간 (초)
+    private float _currentAngle;  // 현재 누적 각도
+    private Vector3 _centerOffset;  // LineBCenter 기준 spurgear1 위치 오프셋 (자전 피벗 보정용)
+    private Quaternion _prevRotation;  // 이전 프레임 회전값 (position 보정용)
+
+    // ============================================================
+    // Unity 메시지
+    // ============================================================
+
+    private void Start()
+    {
+        if (!ValidateComponents()) return;
+        Initialize();
+    }
+
+    /**
+     * @brief  매 프레임 spurgear1 을 자전시킨다.
+     *         IsSignal=true 이고 _duration > 0 인 경우에만 동작한다.
+     *         _duration 경과 시 자동으로 신호를 해제한다.
+     */
+    private void Update()
+    {
+        if (!_isSignal) return;
+        if (_duration <= 0f) return;
+
+        _elapsedTime += Time.deltaTime;
+
+        if (_elapsedTime >= _duration)
+        {
+            _isSignal = false;
+            _elapsedTime = 0f;
+            return;
+        }
+
+        RotateSpurGear();
+
+        Debug.Log($"[SpurGear] LineBCenter={_spurGear1Joint.LineBCenter}");
+    }
+
+    // ============================================================
+    // 초기화
+    // ============================================================
+
+    /**
+     * @brief  초기 각도, 피벗 오프셋, 회전값을 저장한다.
+     */
+    private void Initialize()
+    {
+        _currentAngle = _spurGear1Joint.CurrentAngle;
+        _centerOffset = _spurGear1Joint.ObjectB.position - _spurGear1Joint.LineBCenter;
+        _prevRotation = _spurGear1Joint.ObjectB.rotation;
+
+        Debug.Log($"[SpurGear] 초기화 완료 | initialAngle={_currentAngle}");
+    }
+
+    // ============================================================
+    // 회전 처리
+    // ============================================================
+
+    /**
+     * @brief  spurgear1 을 자전시키고 position 을 보정한다.
+     *         SetAngle() 으로 클램프 포함 rotation 을 적용한 뒤
+     *         rotation 변화량으로 centerOffset 을 회전시켜 자전 피벗을 보정한다.
+     */
+    private void RotateSpurGear()
+    {
+        float direction = _isForward ? 1f : -1f;
+        float deltaAngle = DegreesPerSecond * Time.deltaTime * direction;
+        _currentAngle += deltaAngle;
+
+        _spurGear1Joint.SetAngle(_currentAngle);
+
+        // rotation 변화량으로 centerOffset 갱신 → 자전 피벗 보정
+        Quaternion delta = _spurGear1Joint.ObjectB.rotation * Quaternion.Inverse(_prevRotation);
+        _centerOffset = delta * _centerOffset;
+
+        _spurGear1Joint.ObjectB.position = _spurGear1Joint.LineBCenter + _centerOffset;
+        _prevRotation = _spurGear1Joint.ObjectB.rotation;
+    }
+
+    // ============================================================
+    // 유효성 검사
+    // ============================================================
+
+    /**
+     * @brief  Inspector 할당 필수 오브젝트의 유효성을 검사한다.
+     *         하나라도 미할당 시 컴포넌트를 비활성화하고 false 를 반환한다.
+     * @return bool  모두 유효하면 true
+     */
+    private bool ValidateComponents()
+    {
+        bool isValid = true;
+
+        if (_spurGear1Joint == null)
+        {
+            Debug.LogError("[SpurGear] _spurGear1Joint 가 할당되지 않았습니다.");
+            isValid = false;
+        }
+
+        if (_shuttle == null)
+        {
+            Debug.LogError("[SpurGear] _shuttle 이 할당되지 않았습니다.");
+            isValid = false;
+        }
+
+        if (!isValid) enabled = false;
+        return isValid;
+    }
+}

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/SpurGearController.cs.meta
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/SpurGearController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bdc7ed0fd070fc42a6f829be7b0b567

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/XWheelController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/XWheelController.cs
@@ -1,0 +1,163 @@
+// ============================================================
+// 파일명  : XWheelController.cs
+// 역할    : xwheel1~4 를 회전시키고 셔틀 오브젝트를 Z축 방향으로 이동시킨다.
+//           3초에 1바퀴 기준으로 _duration 초 동안 동작한다.
+//           회전축은 RevoluteJointComponent 에서 가져오고 실제 회전은 Transform 직접 제어한다.
+// 작성자  : 이현화
+// 작성일  : 2026-04-22
+// ============================================================
+
+using UnityEngine;
+
+public class XWheelController : MonoBehaviour
+{
+    [SerializeField] private Transform _shuttle;                        // 셔틀 최상위 부모 (Z축 이동 대상)
+    [SerializeField] private RevoluteJointComponent _xwheel1Joint;     // 바퀴 1 조인트
+    [SerializeField] private RevoluteJointComponent _xwheel2Joint;     // 바퀴 2 조인트
+    [SerializeField] private RevoluteJointComponent _xwheel3Joint;     // 바퀴 3 조인트
+    [SerializeField] private RevoluteJointComponent _xwheel4Joint;     // 바퀴 4 조인트
+    [SerializeField] private float _duration;                          // 이동 지속 시간 (초) — 3초당 1바퀴 기준
+    [SerializeField] private bool _isSignal = false;                   // 신호 on/off (테스트용)
+    [SerializeField] private bool _isForward = true;                   // 이동 방향 (true: 정방향, false: 역방향)
+
+    private const float SecondsPerRotation = 3f;                           // 1바퀴당 걸리는 시간 (초)
+    private const float DegreesPerSecond = 360f / SecondsPerRotation;     // 초당 회전 각도
+
+    private float _wheelRadius;                 // 바퀴 반지름 (메쉬에서 자동 계산)
+    private float _elapsedTime;                 // 경과 시간 (초)
+    private Vector3 _initialShuttlePosition;    // 셔틀 초기 위치 (이동량 계산용)
+
+    // LineBCenter 기준 각 바퀴의 초기 offset (자전 피벗 보정용)
+    private Vector3 _centerOffset1;  // LineBCenter 기준 xwheel1 위치 offset
+    private Vector3 _centerOffset2;  // LineBCenter 기준 xwheel2 위치 offset
+    private Vector3 _centerOffset3;  // LineBCenter 기준 xwheel3 위치 offset
+    private Vector3 _centerOffset4;  // LineBCenter 기준 xwheel4 위치 offset
+
+    /**
+     * @brief  유효성 검사 → 반지름 계산 → offset 초기화 → 셔틀 초기 위치 저장 순서로 실행한다.
+     */
+    private void Start()
+    {
+        if (!ValidateComponents()) return;
+        InitializeWheelRadius();
+        InitializeCenterOffsets();
+        _initialShuttlePosition = _shuttle.position;  // 셔틀 초기 위치 저장 (이동량 계산용)
+
+        Debug.Log($"XWheelController: wheelRadius = {_wheelRadius}");
+    }
+
+    /**
+     * @brief  매 프레임 바퀴를 자전시키고 셔틀 오브젝트를 Z축 방향으로 이동시킨다.
+     *         _isSignal 이 true 일 때만 동작하며 _duration 초 동안 실행된다.
+     *         _isForward 로 이동 방향을 결정한다 (true: 정방향, false: 역방향).
+     *         모든 바퀴에 동일한 회전 Quaternion 을 적용하며 월드 기준으로 회전한다.
+     *         LineBCenter 기준 offset 과 셔틀 이동량을 반영하여 자전을 구현한다.
+     */
+    private void Update()
+    {
+        if (!_isSignal) return;          // 신호 없으면 실행 안 함
+        if (_duration <= 0) return;      // duration 이 없으면 실행 안 함
+
+        _elapsedTime += Time.deltaTime;  // 경과 시간 누적
+
+        if (_elapsedTime >= _duration)   // duration 초과 시 신호 초기화
+        {
+            _isSignal = false;
+            _elapsedTime = 0f;
+            return;
+        }
+
+        // 이동 방향 보정 (정방향: 1, 역방향: -1)
+        float direction = _isForward ? 1f : -1f;
+
+        // 이번 프레임 회전 각도 계산
+        float anglePerFrame = DegreesPerSecond * Time.deltaTime * direction;
+
+        // 월드 기준 회전 Quaternion (모든 바퀴에 동일하게 적용)
+        Quaternion rotation = Quaternion.AngleAxis(-anglePerFrame, _xwheel1Joint.ObjectBRotationAxis);
+
+        // 셔틀 이동량 계산 (초기 위치 기준)
+        Vector3 shuttleOffset = _shuttle.position - _initialShuttlePosition;
+
+        // 모든 바퀴에 동일한 회전 적용
+        RotateWheel(_xwheel1Joint, rotation, ref _centerOffset1, shuttleOffset);
+        RotateWheel(_xwheel2Joint, rotation, ref _centerOffset2, shuttleOffset);
+        RotateWheel(_xwheel3Joint, rotation, ref _centerOffset3, shuttleOffset);
+        RotateWheel(_xwheel4Joint, rotation, ref _centerOffset4, shuttleOffset);
+
+        // 이동 거리 계산: 바퀴 반지름 × 회전각(rad)
+        float moveDistance = _wheelRadius * anglePerFrame * Mathf.Deg2Rad;
+
+        // 셔틀 Z축 방향으로 이동
+        _shuttle.position += Vector3.forward * moveDistance;
+    }
+
+    /**
+     * @brief  필수 오브젝트 유효성 검사.
+     *         wheel 조인트 또는 셔틀이 할당되지 않으면 false 를 반환하고 컴포넌트를 비활성화한다.
+     * @return bool  유효하면 true, 아니면 false
+     */
+    private bool ValidateComponents()
+    {
+        if (_xwheel1Joint == null || _xwheel2Joint == null ||
+            _xwheel3Joint == null || _xwheel4Joint == null)
+        {
+            Debug.LogError("XWheelController: wheel 조인트가 할당되지 않았습니다.");
+            enabled = false;  // Update 호출 중단 (NullReferenceException 방지)
+            return false;
+        }
+
+        if (_shuttle == null)
+        {
+            Debug.LogError("XWheelController: 셔틀 오브젝트가 할당되지 않았습니다.");
+            enabled = false;
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief  xwheel1 의 메쉬 바운딩 박스에서 바퀴 반지름을 자동 계산한다.
+     *         extents.y = 바운딩 박스 Y축 절반 크기 = 반지름 (로컬 좌표 기준)
+     *         lossyScale.y = 월드 기준 실제 스케일 → 실제 반지름으로 변환
+     */
+    private void InitializeWheelRadius()
+    {
+        MeshFilter meshFilter = _xwheel1Joint.ObjectB.GetComponent<MeshFilter>();
+        Bounds bounds = meshFilter.mesh.bounds;
+        _wheelRadius = bounds.extents.y * _xwheel1Joint.ObjectB.lossyScale.y;
+    }
+
+    /**
+     * @brief  LineBCenter 기준 각 바퀴의 초기 offset 을 계산한다.
+     *         RevoluteFreezeTestManager 와 동일한 방식으로 중심점과의 차이를 저장한다.
+     */
+    private void InitializeCenterOffsets()
+    {
+        _centerOffset1 = _xwheel1Joint.ObjectB.position - _xwheel1Joint.LineBCenter;
+        _centerOffset2 = _xwheel2Joint.ObjectB.position - _xwheel2Joint.LineBCenter;
+        _centerOffset3 = _xwheel3Joint.ObjectB.position - _xwheel3Joint.LineBCenter;
+        _centerOffset4 = _xwheel4Joint.ObjectB.position - _xwheel4Joint.LineBCenter;
+    }
+
+    /**
+     * @brief  LineBCenter 기준 offset 과 셔틀 이동량을 반영하여 바퀴를 자전시킨다.
+     *         RevoluteFreezeTestManager 와 동일한 방식으로 중심점 기준 위치 보정 후 회전 적용한다.
+     * @param  joint          회전 대상 RevoluteJointComponent
+     * @param  rotation       적용할 회전 Quaternion
+     * @param  offset         LineBCenter 기준 바퀴 위치 offset (ref 로 갱신됨)
+     * @param  shuttleOffset  셔틀 이동량 (초기 위치 기준)
+     */
+    private void RotateWheel(RevoluteJointComponent joint, Quaternion rotation, ref Vector3 offset, Vector3 shuttleOffset)
+    {
+        // offset 을 회전시켜 중심점 기준 위치 보정
+        offset = rotation * offset;
+
+        // LineBCenter + 셔틀 이동량 + offset 으로 위치 보정
+        joint.ObjectB.position = joint.LineBCenter + shuttleOffset + offset;
+
+        // 회전 적용
+        joint.ObjectB.rotation = rotation * joint.ObjectB.rotation;
+    }
+}

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/XWheelController.cs.meta
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/XWheelController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3aaf17f18214c6e4da7f9e6f1a28da5d

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/YWheelController.cs
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/YWheelController.cs
@@ -1,6 +1,6 @@
 // ============================================================
-// 파일명  : XWheelController.cs
-// 역할    : xwheel1~4 를 자전시키고 셔틀을 Z축 방향으로 이동시킨다.
+// 파일명  : YWheelController.cs
+// 역할    : ywheel1~4 를 자전시키고 셔틀을 X축 방향으로 이동시킨다.
 //           3초에 1바퀴 기준으로 _duration 초 동안 동작한다.
 //           회전축은 RevoluteJointComponent 에서 가져오고
 //           실제 회전은 Transform 을 직접 제어한다.
@@ -11,18 +11,18 @@
 
 using UnityEngine;
 
-public class XWheelController : MonoBehaviour
+public class YWheelController : MonoBehaviour
 {
     // ============================================================
     // Inspector 필드
     // ============================================================
 
     [Header("필수 오브젝트")]
-    [SerializeField] private Transform _shuttle;       // 셔틀 최상위 Transform (Z축 이동 대상)
-    [SerializeField] private RevoluteJointComponent _xwheel1Joint; // xwheel1 조인트
-    [SerializeField] private RevoluteJointComponent _xwheel2Joint; // xwheel2 조인트
-    [SerializeField] private RevoluteJointComponent _xwheel3Joint; // xwheel3 조인트
-    [SerializeField] private RevoluteJointComponent _xwheel4Joint; // xwheel4 조인트
+    [SerializeField] private Transform _shuttle;       // 셔틀 최상위 Transform (X축 이동 대상)
+    [SerializeField] private RevoluteJointComponent _ywheel1Joint; // ywheel1 조인트
+    [SerializeField] private RevoluteJointComponent _ywheel2Joint; // ywheel2 조인트
+    [SerializeField] private RevoluteJointComponent _ywheel3Joint; // ywheel3 조인트
+    [SerializeField] private RevoluteJointComponent _ywheel4Joint; // ywheel4 조인트
 
     [Header("파라미터")]
     [SerializeField] private float _duration = 0f;   // 이동 지속 시간 (초) — 3초당 1바퀴 기준
@@ -40,7 +40,7 @@ public class XWheelController : MonoBehaviour
     // 런타임 상태
     // ============================================================
 
-    private float _wheelRadius; // 바퀴 반지름 (xwheel1 메쉬에서 자동 계산)
+    private float _wheelRadius; // 바퀴 반지름 (ywheel1 메쉬에서 자동 계산)
     private float _elapsedTime; // 경과 시간 (초)
 
     // LineBCenter 기준 각 바퀴의 위치 오프셋 (자전 피벗 보정용)
@@ -59,11 +59,11 @@ public class XWheelController : MonoBehaviour
         InitializeWheelRadius();
         InitializeCenterOffsets();
 
-        Debug.Log($"[XWheel] 초기화 완료 | wheelRadius={_wheelRadius}");
+        Debug.Log($"[YWheel] 초기화 완료 | wheelRadius={_wheelRadius}");
     }
 
     /**
-     * @brief  매 프레임 xwheel1~4 를 자전시키고 셔틀을 Z축으로 이동시킨다.
+     * @brief  매 프레임 ywheel1~4 를 자전시키고 셔틀을 X축으로 이동시킨다.
      *         IsSignal=true 이고 _duration > 0 인 경우에만 동작한다.
      *         _duration 경과 시 자동으로 신호를 해제한다.
      */
@@ -84,15 +84,15 @@ public class XWheelController : MonoBehaviour
         float direction = _isForward ? 1f : -1f;
         float deltaAngle = DegreesPerSecond * Time.deltaTime * direction;
 
-        Quaternion rotation = Quaternion.AngleAxis(-deltaAngle, _xwheel1Joint.ObjectBRotationAxis);
+        Quaternion rotation = Quaternion.AngleAxis(deltaAngle, _ywheel1Joint.ObjectBRotationAxis);
 
-        RotateWheel(_xwheel1Joint, rotation, ref _centerOffset1);
-        RotateWheel(_xwheel2Joint, rotation, ref _centerOffset2);
-        RotateWheel(_xwheel3Joint, rotation, ref _centerOffset3);
-        RotateWheel(_xwheel4Joint, rotation, ref _centerOffset4);
+        RotateWheel(_ywheel1Joint, rotation, ref _centerOffset1);
+        RotateWheel(_ywheel2Joint, rotation, ref _centerOffset2);
+        RotateWheel(_ywheel3Joint, rotation, ref _centerOffset3);
+        RotateWheel(_ywheel4Joint, rotation, ref _centerOffset4);
 
         float moveDistance = _wheelRadius * deltaAngle * Mathf.Deg2Rad;
-        _shuttle.position += Vector3.forward * moveDistance;
+        _shuttle.position += Vector3.right * moveDistance;
     }
 
     // ============================================================
@@ -100,14 +100,14 @@ public class XWheelController : MonoBehaviour
     // ============================================================
 
     /**
-     * @brief  xwheel1 메쉬 바운딩 박스에서 바퀴 반지름을 자동 계산한다.
+     * @brief  ywheel1 메쉬 바운딩 박스에서 바퀴 반지름을 자동 계산한다.
      *         extents.y = Y축 절반 크기 = 반지름 (로컬 좌표)
      *         lossyScale.y 를 곱해 월드 기준 실제 반지름으로 변환한다.
      */
     private void InitializeWheelRadius()
     {
-        Bounds bounds = _xwheel1Joint.ObjectB.GetComponent<MeshFilter>().mesh.bounds;
-        _wheelRadius = bounds.extents.y * _xwheel1Joint.ObjectB.lossyScale.y;
+        Bounds bounds = _ywheel1Joint.ObjectB.GetComponent<MeshFilter>().mesh.bounds;
+        _wheelRadius = bounds.extents.y * _ywheel1Joint.ObjectB.lossyScale.y;
     }
 
     /**
@@ -115,10 +115,10 @@ public class XWheelController : MonoBehaviour
      */
     private void InitializeCenterOffsets()
     {
-        _centerOffset1 = _xwheel1Joint.ObjectB.position - _xwheel1Joint.LineBCenter;
-        _centerOffset2 = _xwheel2Joint.ObjectB.position - _xwheel2Joint.LineBCenter;
-        _centerOffset3 = _xwheel3Joint.ObjectB.position - _xwheel3Joint.LineBCenter;
-        _centerOffset4 = _xwheel4Joint.ObjectB.position - _xwheel4Joint.LineBCenter;
+        _centerOffset1 = _ywheel1Joint.ObjectB.position - _ywheel1Joint.LineBCenter;
+        _centerOffset2 = _ywheel2Joint.ObjectB.position - _ywheel2Joint.LineBCenter;
+        _centerOffset3 = _ywheel3Joint.ObjectB.position - _ywheel3Joint.LineBCenter;
+        _centerOffset4 = _ywheel4Joint.ObjectB.position - _ywheel4Joint.LineBCenter;
     }
 
     // ============================================================
@@ -152,16 +152,16 @@ public class XWheelController : MonoBehaviour
     {
         bool isValid = true;
 
-        if (_xwheel1Joint == null || _xwheel2Joint == null ||
-            _xwheel3Joint == null || _xwheel4Joint == null)
+        if (_ywheel1Joint == null || _ywheel2Joint == null ||
+            _ywheel3Joint == null || _ywheel4Joint == null)
         {
-            Debug.LogError("[XWheel] xwheel 조인트가 할당되지 않았습니다.");
+            Debug.LogError("[YWheel] ywheel 조인트가 할당되지 않았습니다.");
             isValid = false;
         }
 
         if (_shuttle == null)
         {
-            Debug.LogError("[XWheel] _shuttle 이 할당되지 않았습니다.");
+            Debug.LogError("[YWheel] _shuttle 이 할당되지 않았습니다.");
             isValid = false;
         }
 

--- a/unity/Assets/Scripts/Controllers/Unity Freeze Test/YWheelController.cs.meta
+++ b/unity/Assets/Scripts/Controllers/Unity Freeze Test/YWheelController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4bf59b29b7ca13a4cae8ef8825f9684a

--- a/unity/Assets/Scripts/Core/Line.cs
+++ b/unity/Assets/Scripts/Core/Line.cs
@@ -3,15 +3,18 @@
 // 역할    : 기구학 계산을 위한 선(Line) 기반 클래스
 // 작성자  : 이현화
 // 작성일  : 2026-03-24
-// 수정이력: 
+// 수정이력: 2026-04-24 - Tolerance 를 1e-6f → 0.02f 로 조정
+//                        (ConstraintAssemblyWindow Edge 선택 시 발생하는 미세 좌표 오차 허용)
 // ============================================================
 
 using UnityEngine;
 
 public class Line
 {
-    // 허용 오차 (부동소수점 비교 시 사용)
-    private const float Tolerance = 1e-6f;
+    // [2026.04.24 수정] Tolerance 를 1e-6f → 0.01f → 0.02f 로 조정
+    //                  ConstraintAssemblyWindow 에서 Edge 선택 시 발생하는
+    //                  미세 좌표 오차(약 0.01 수준)를 허용하기 위함
+    private const float Tolerance = 0.02f;
 
     private Vector3 _pointA;    // 선의 시작점
     private Vector3 _pointB;    // 선의 끝점

--- a/unity/Assets/Scripts/Core/Plane.cs
+++ b/unity/Assets/Scripts/Core/Plane.cs
@@ -3,7 +3,9 @@
 // 역할    : 기구학 계산을 위한 면(Plane) 기반 클래스
 // 작성자  : 이현화
 // 작성일  : 2026-03-25
-// 수정이력: 
+// 수정이력: 2026-04-22 - Tolerance 를 0.01f 로 조정 (확장프로그램 기반 면 선택 오차 허용)
+//                      - GetCrossVectors() 에서 crossPosition 절대값 처리
+//                        (법선 방향이 반대인 경우도 일치로 처리)
 // ============================================================
 
 using UnityEngine;
@@ -11,7 +13,8 @@ using UnityEngine;
 public class Plane
 {
     // 허용 오차 (부동소수점 비교 시 사용)
-    private const float Tolerance = 1e-6f;
+    // [2026.04.22 수정] 확장프로그램 기반 면 선택 시 발생하는 미세 오차를 허용하기 위해 0.01f 로 조정
+    private const float Tolerance = 0.01f;
 
     private Vector3 _pointA;   // 면을 정의하는 첫 번째 점
     private Vector3 _pointB;   // 면을 정의하는 두 번째 점
@@ -51,7 +54,6 @@ public class Plane
     public bool IsParallel(Plane other)
     {
         // 1. 두 면의 방향 외적과 위치 외적을 계산
-        //    → GetCrossVectors() 로 외적 계산하기
         GetCrossVectors(other, out Vector3 crossDirection, out float crossPosition);
 
         // 2. 반환 조건
@@ -87,9 +89,9 @@ public class Plane
 
     /**
      * @brief  두 면의 방향 외적과 위치 외적을 계산한다.
-     * @param  other        비교할 대상 Plane
-     * @param  crossDir     방향벡터 외적 결과 (out)
-     * @param  crossPos     위치벡터 외적 결과 (out)
+     * @param  other            비교할 대상 Plane
+     * @param  crossDirection   방향벡터 외적 결과 (out)
+     * @param  crossPosition    위치벡터 외적 결과 (out)
      */
     private void GetCrossVectors(Plane other, out Vector3 crossDirection, out float crossPosition)
     {
@@ -104,10 +106,13 @@ public class Plane
         //    "끝점 - 시작점" 규칙: other.PointA - _pointA
         Vector3 dirToOther = other.PointA - _pointA;
 
-        // 3. 방향벡터와 dir 의 내적 계산
+        // [2026.04.22 수정] 법선 방향이 반대인 경우도 일치로 처리
+        // 3. 방향벡터와 dir 의 내적 절대값 계산
         //    크기 = 0 이면 → 두 면이 같은 평면 (일치)
         //    크기 > 0 이면 → 두 면이 다른 위치에 있음 (평행)
-        crossPosition = Vector3.Dot(Normal, dirToOther);
+        //    절대값을 사용하는 이유: 법선이 반대 방향일 때 내적이 음수가 되어
+        //    일치 판별이 실패하는 것을 방지하기 위함
+        crossPosition = Mathf.Abs(Vector3.Dot(Normal, dirToOther));
     }
 
     /**
@@ -119,7 +124,6 @@ public class Plane
     public bool IsCoincident(Plane other)
     {
         // 1. 두 면의 방향 외적과 위치 외적을 계산
-        //    → GetCrossVectors() 로 외적 계산하기
         GetCrossVectors(other, out Vector3 crossDirection, out float crossPosition);
 
         // 2. 반환 조건

--- a/unity/Assets/Scripts/Editor/ConstraintAssemblyWindow.cs
+++ b/unity/Assets/Scripts/Editor/ConstraintAssemblyWindow.cs
@@ -640,6 +640,11 @@ public class ConstraintAssemblyWindow : EditorWindow
             SetSerializedField(comp, "_objectA", _objectA.transform);
             SetSerializedField(comp, "_objectB", _objectB.transform);
             SetSerializedField(comp, "_rotationAxis", _lineA.Direction);
+            // [2026.04.21 추가] 선택된 Line 점 좌표 저장
+            SetSerializedField(comp, "_lineAPointA", _lineA.PointA);
+            SetSerializedField(comp, "_lineAPointB", _lineA.PointB);
+            SetSerializedField(comp, "_lineBPointA", _lineB.PointA);
+            SetSerializedField(comp, "_lineBPointB", _lineB.PointB);
         }
         else
         {
@@ -647,6 +652,17 @@ public class ConstraintAssemblyWindow : EditorWindow
             SetSerializedField(comp, "_objectA", _objectA.transform);
             SetSerializedField(comp, "_objectB", _objectB.transform);
             SetSerializedField(comp, "_moveDirection", _lineA.Direction);
+            // [2026.04.21 추가] 선택된 Line, Plane 점 좌표 저장
+            SetSerializedField(comp, "_lineAPointA", _lineA.PointA);
+            SetSerializedField(comp, "_lineAPointB", _lineA.PointB);
+            SetSerializedField(comp, "_lineBPointA", _lineB.PointA);
+            SetSerializedField(comp, "_lineBPointB", _lineB.PointB);
+            SetSerializedField(comp, "_planeAPointA", _planeA.PointA);
+            SetSerializedField(comp, "_planeAPointB", _planeA.PointB);
+            SetSerializedField(comp, "_planeAPointC", _planeA.PointC);
+            SetSerializedField(comp, "_planeBPointA", _planeB.PointA);
+            SetSerializedField(comp, "_planeBPointB", _planeB.PointB);
+            SetSerializedField(comp, "_planeBPointC", _planeB.PointC);
         }
 
         // ⑤ 생성된 Manager 를 씬에서 선택
@@ -703,13 +719,15 @@ public class ConstraintAssemblyWindow : EditorWindow
     {
         if (_lineA == null || _lineB == null) return;
 
-        // LineB 의 시작점을 LineA 무한직선 위에 투영
         Vector3 projectedPoint = _lineA.Project(_lineB.PointA);
-
-        // 투영점과 LineB 시작점의 차이 = B 를 이동시킬 오프셋
         Vector3 offset = projectedPoint - _lineB.PointA;
-
         tB.position += offset;
+
+        // [2026.04.21 추가] 스냅 후 lineB 좌표 업데이트 및 방향 일치
+        if (Vector3.Dot(_lineA.Direction, _lineB.Direction) < 0)
+            _lineB = new Line(_lineB.PointB + offset, _lineB.PointA + offset);
+        else
+            _lineB = new Line(_lineB.PointA + offset, _lineB.PointB + offset);
 
         Debug.Log($"[구속 조건 조립] RevoluteJoint 스냅: {tB.name} 을 회전축 위로 이동 (offset: {FormatVec(offset)})");
     }

--- a/unity/Assets/Tests/Editor/LineTest.cs
+++ b/unity/Assets/Tests/Editor/LineTest.cs
@@ -15,7 +15,7 @@ public class LineTest
     // ──────────────────────────────────────────────
     // 공용 Tolerance (Line.cs 와 동일값)
     // ──────────────────────────────────────────────
-    private const float Tolerance = 1e-6f;
+    private const float Tolerance = 0.02f; // [2026.04.24 수정] Line.cs 의 Tolerance 와 동일값으로 설정
 
     // ============================================================
     // [1] IsCoincident — 동일선 판별
@@ -510,7 +510,7 @@ public class LineTest
     {
         var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
         // Y 성분에 Tolerance 보다 10배 작은 노이즈 추가
-        Vector3 noisyPoint = new Vector3(2f, 1e-7f, 0f);
+        Vector3 noisyPoint = new Vector3(2f, 0.01f, 0f);  // [2026.04.24 수정] Tolerance(0.02f) 이내
         Assert.IsTrue(line.Contains(noisyPoint),
             "1e-7 수준 노이즈를 선 위 점으로 인식 못함");
     }
@@ -523,7 +523,7 @@ public class LineTest
     {
         var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
         // Y 성분이 Tolerance(1e-6) 보다 10배 크면 → false
-        Vector3 point = new Vector3(2f, 1e-5f, 0f);
+        Vector3 point = new Vector3(2f, 0.03f, 0f);  // [2026.04.24 수정] Tolerance(0.02f) 바깥
         Assert.IsFalse(line.Contains(point),
             "Tolerance 바깥 점이 선 위로 인식됨");
     }

--- a/unity/Assets/Tests/Editor/LineTest.cs
+++ b/unity/Assets/Tests/Editor/LineTest.cs
@@ -5,6 +5,10 @@
 // 작성일  : 2026-03-24
 // 사용법  : Unity Test Runner (EditMode) 에서 실행
 //           Window > General > Test Runner > EditMode > Run All
+// 수정이력: 2026-04-24 - Contains_OffLine_ReturnsFalse 테스트 수정
+//                        Y 오프셋 0.001f → 0.03f 로 변경
+//                        (Tolerance 가 0.02f 로 변경됨에 따라 0.001f 는
+//                        허용 범위 내로 들어가 테스트가 실패하는 문제 수정)
 // ============================================================
 
 using NUnit.Framework;
@@ -294,13 +298,16 @@ public class LineTest
     }
 
     /// <summary>
-    /// 선에서 살짝 벗어난 점 → false
+    /// 선에서 Tolerance(0.02f) 바깥으로 벗어난 점 → false
+    /// [2026.04.24 수정] Y 오프셋 0.001f → 0.03f 로 변경
+    ///                  Tolerance 가 0.02f 로 변경됨에 따라 0.001f 는
+    ///                  허용 범위 내로 들어가 테스트가 실패하는 문제 수정
     /// </summary>
     [Test]
     public void Contains_OffLine_ReturnsFalse()
     {
         var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
-        Assert.IsFalse(line.Contains(new Vector3(0.5f, 0.001f, 0))); // Y 방향으로 살짝 벗어남
+        Assert.IsFalse(line.Contains(new Vector3(0.5f, 0.03f, 0))); // [2026.04.24 수정] 0.001f → 0.03f
     }
 
     // ============================================================
@@ -364,7 +371,7 @@ public class LineTest
         var line = new Line(new Vector3(0, 0, 0), new Vector3(2, 2, 0));
         Vector3 result = line.Project(new Vector3(2, 0, 0));
 
-        Assert.AreEqual(1f, result.x, 0.0001f); // 수치 계산 오차 허용
+        Assert.AreEqual(1f, result.x, 0.0001f);
         Assert.AreEqual(1f, result.y, 0.0001f);
         Assert.AreEqual(0f, result.z, 0.0001f);
     }
@@ -436,9 +443,8 @@ public class LineTest
         var b = new Line(new Vector3(-1, 0, 0), new Vector3(5, 0, 0)); // 동일 X축
 
         bool coincident = a.IsCoincident(b);
-        bool parallel   = a.IsParallel(b);
+        bool parallel = a.IsParallel(b);
 
-        // 일치이면 평행이 아니어야 하고, 평행이면 일치가 아니어야 한다
         Assert.IsTrue(coincident != parallel,
             $"IsCoincident={coincident}, IsParallel={parallel} — 둘 다 같은 값이면 안 됨");
     }
@@ -495,35 +501,34 @@ public class LineTest
         Vector3 point = new Vector3(3, -2, 5);
 
         float distFromMethod = line.Distance(point);
-        float distManual     = Vector3.Distance(point, line.Project(point));
+        float distManual = Vector3.Distance(point, line.Project(point));
 
         Assert.AreEqual(distManual, distFromMethod, Tolerance,
             "Distance() 와 Vector3.Distance(point, Project()) 결과가 다름");
     }
 
     /// <summary>
-    /// 복합 트랩 5: 부동소수점 누적 오차 — 아주 작은 수치 차이가 Contains 판별에 영향을 주는가
-    /// 1e-7 수준의 오차를 가진 점은 Tolerance(1e-6) 이내이므로 Contains = true 이어야 한다
+    /// 복합 트랩 5: Tolerance(0.02f) 이내의 노이즈를 가진 점은 Contains = true 이어야 한다
+    /// [2026.04.24 수정] 노이즈값 1e-7 → 0.01f 로 변경 (Tolerance 0.02f 이내)
     /// </summary>
     [Test]
     public void Trap_FloatingPoint_SmallNoise_StillContained()
     {
         var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
-        // Y 성분에 Tolerance 보다 10배 작은 노이즈 추가
-        Vector3 noisyPoint = new Vector3(2f, 0.01f, 0f);  // [2026.04.24 수정] Tolerance(0.02f) 이내
+        Vector3 noisyPoint = new Vector3(2f, 0.01f, 0f); // [2026.04.24 수정] Tolerance(0.02f) 이내
         Assert.IsTrue(line.Contains(noisyPoint),
-            "1e-7 수준 노이즈를 선 위 점으로 인식 못함");
+            "Tolerance 이내 노이즈를 선 위 점으로 인식 못함");
     }
 
     /// <summary>
-    /// 복합 트랩 6: Tolerance 경계 바로 바깥 → Contains = false 이어야 한다
+    /// 복합 트랩 6: Tolerance(0.02f) 경계 바로 바깥 → Contains = false 이어야 한다
+    /// [2026.04.24 수정] 기준값 수정 (Tolerance 0.02f 바깥인 0.03f 사용)
     /// </summary>
     [Test]
     public void Trap_FloatingPoint_JustOutsideTolerance_NotContained()
     {
         var line = new Line(new Vector3(0, 0, 0), new Vector3(1, 0, 0));
-        // Y 성분이 Tolerance(1e-6) 보다 10배 크면 → false
-        Vector3 point = new Vector3(2f, 0.03f, 0f);  // [2026.04.24 수정] Tolerance(0.02f) 바깥
+        Vector3 point = new Vector3(2f, 0.03f, 0f); // [2026.04.24 수정] Tolerance(0.02f) 바깥
         Assert.IsFalse(line.Contains(point),
             "Tolerance 바깥 점이 선 위로 인식됨");
     }

--- a/unity/Assets/Tests/Editor/PlaneTest.cs
+++ b/unity/Assets/Tests/Editor/PlaneTest.cs
@@ -3,7 +3,8 @@
 // 역할    : Plane 클래스 단위 테스트 (EditMode)
 // 작성자  : 이현화
 // 작성일  : 2026-03-25
-// 수정이력:
+// 수정이력: 2026-04-22 - Contains_Point_SmallEpsilonOff_ReturnsFalse 테스트 케이스 수정
+//                        (Tolerance 가 0.01f 로 변경됨에 따라 테스트 기준값 조정)
 // ============================================================
 
 using NUnit.Framework;
@@ -419,10 +420,10 @@ public class PlaneTest
     [Test]
     public void Contains_Point_SmallEpsilonOff_ReturnsFalse()
     {
-        // Tolerance(1e-6) 바로 밖 → false
+        // [2026.04.22 수정]Tolerance(0.01f) 바로 밖 → false
         Plane plane = XYPlane();
 
-        Assert.IsFalse(plane.Contains(new Vector3(0f, 0f, 2e-6f)));
+        Assert.IsFalse(plane.Contains(new Vector3(0f, 0f, 0.02f)));
     }
 
     [Test]

--- a/unity/Assets/Tests/RevoluteJointComponentPlayModeTest.cs
+++ b/unity/Assets/Tests/RevoluteJointComponentPlayModeTest.cs
@@ -1,10 +1,14 @@
 // ============================================================
-// 파일명  : RevoluteJointComponentPlayModeTest.cs
-// 역할    : RevoluteJointComponent 클래스의 PlayMode 통합 테스트
-//           실제 씬 환경에서 Rigidbody, 물리 연산, 회전 클램프를 검증한다.
-// 작성자  : 이현화
-// 작성일  : 2026-04-01
-// 수정이력: 
+// 파일명  : RevoluteJointComponentPlayModeTest.cs
+// 역할    : RevoluteJointComponent 클래스의 PlayMode 통합 테스트
+//           실제 씬 환경에서 Transform 직접 제어, 회전 클램프를 검증한다.
+// 작성자  : 이현화
+// 작성일  : 2026-04-01
+// 수정이력: 2026-04-22 - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        (Gravity 테스트 제거, Constraints 테스트 제거)
+//                      - SetupJointComponent() 에서 Rigidbody 생성 코드 제거
+//                      - 회전 입력 방식을 Transform.rotation 직접 제어로 변경
+//                      - _rotationAxis Reflection 제거 (_lineAPointA/B, _lineBPointA/B 방식으로 변경)
 // ============================================================
 
 using System.Collections;
@@ -23,35 +27,31 @@ public class RevoluteJointComponentPlayModeTest
     private GameObject _managerObject;
     private RevoluteJointComponent _jointComponent;
 
-    #region Setup / Teardown
+    #region Setup / Teardown
 
-    /**
-     * @brief  각 테스트 전 씬 오브젝트를 생성한다.
-     */
-    [SetUp]
+    /**
+     * @brief  각 테스트 전 씬 오브젝트를 생성한다.
+     */
+    [SetUp]
     public void SetUp()
     {
-        // 오브젝트 A 생성 (기준, Kinematic)
-        _objectA = new GameObject("ObjectA");
+        // 오브젝트 A 생성 (기준)
+        _objectA = new GameObject("ObjectA");
         _objectA.transform.position = Vector3.zero;
-        Rigidbody rbA = _objectA.AddComponent<Rigidbody>();
-        rbA.isKinematic = true;
 
-        // 오브젝트 B 생성 (회전 대상)
-        _objectB = new GameObject("ObjectB");
+        // 오브젝트 B 생성 (회전 대상)
+        _objectB = new GameObject("ObjectB");
         _objectB.transform.position = Vector3.zero;
-        _objectB.transform.rotation = Quaternion.Euler(0, 0, 90);  // 초기 회전
-        Rigidbody rbB = _objectB.AddComponent<Rigidbody>();
-        rbB.useGravity = false;
+        _objectB.transform.rotation = Quaternion.Euler(0, 0, 90);  // 초기 회전
 
-        // RevoluteJointComponent 를 별도 오브젝트에 추가
-        _managerObject = new GameObject("JointManager");
+        // RevoluteJointComponent 를 별도 오브젝트에 추가
+        _managerObject = new GameObject("JointManager");
     }
 
-    /**
-     * @brief  각 테스트 후 씬 오브젝트를 정리한다.
-     */
-    [TearDown]
+    /**
+     * @brief  각 테스트 후 씬 오브젝트를 정리한다.
+     */
+    [TearDown]
     public void TearDown()
     {
         if (_objectA != null) Object.Destroy(_objectA);
@@ -59,20 +59,19 @@ public class RevoluteJointComponentPlayModeTest
         if (_managerObject != null) Object.Destroy(_managerObject);
     }
 
-    /**
-     * @brief  RevoluteJointComponent 를 설정하고 초기화한다.
-     * @param  minAngle     최소 회전 각도
-     * @param  maxAngle     최대 회전 각도
-     * @param  rotationAxis 회전축 (월드 기준)
-     */
-    private void SetupJointComponent(float minAngle, float maxAngle, Vector3 rotationAxis)
+    /**
+     * @brief  RevoluteJointComponent 를 설정하고 초기화한다.
+     *         회전축은 rotationAxis 방향으로 lineA, lineB 를 생성하여 설정한다.
+     * @param  minAngle     최소 회전 각도
+     * @param  maxAngle     최대 회전 각도
+     * @param  rotationAxis 회전축 (월드 기준)
+     */
+    private void SetupJointComponent(float minAngle, float maxAngle, Vector3 rotationAxis)
     {
-        // 먼저 컴포넌트를 비활성 상태로 추가 (Awake 방지)
         _managerObject.SetActive(false);
         _jointComponent = _managerObject.AddComponent<RevoluteJointComponent>();
 
-        // Reflection 으로 private SerializeField 설정
-        var type = typeof(RevoluteJointComponent);
+        var type = typeof(RevoluteJointComponent);
         var baseType = typeof(JointComponent);
 
         baseType.GetField("_objectA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
@@ -84,409 +83,308 @@ public class RevoluteJointComponentPlayModeTest
           .SetValue(_jointComponent, minAngle);
         type.GetField("_maxAngle", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
           .SetValue(_jointComponent, maxAngle);
-        type.GetField("_rotationAxis", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-          .SetValue(_jointComponent, rotationAxis);
 
-        // 3. 오브젝트 활성화 (이때 Awake가 호출됨)
+        // 회전축 Line 점 좌표 설정 (rotationAxis 방향으로 lineA, lineB 생성)
+        Vector3 pointA = Vector3.zero;
+        Vector3 pointB = rotationAxis.normalized;
+
+        type.GetField("_lineAPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+          .SetValue(_jointComponent, pointA);
+        type.GetField("_lineAPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+          .SetValue(_jointComponent, pointB);
+        type.GetField("_lineBPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+          .SetValue(_jointComponent, pointA);
+        type.GetField("_lineBPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+          .SetValue(_jointComponent, pointB);
+
         _managerObject.SetActive(true);
     }
 
-    #endregion
+    #endregion
 
-    #region 기본 동작 테스트
+    #region 기본 동작 테스트
 
-    /**
-     * @brief  컴포넌트 초기화 테스트 - Awake 후 컴포넌트가 정상 초기화되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  컴포넌트 초기화 테스트 - Awake 후 컴포넌트가 정상 초기화되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator Initialization_AfterAwake_ComponentInitializes()
     {
-        // Arrange & Act
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;  // Awake 실행 대기
+        // Arrange & Act
+        SetupJointComponent(-90f, 90f, Vector3.right);
+        yield return null;
 
-        // Assert
-        Assert.IsNotNull(_jointComponent);
+        // Assert
+        Assert.IsNotNull(_jointComponent);
         Assert.AreEqual(0f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    /**
-     * @brief  회전축 프로퍼티 테스트 - ObjectBRotationAxis 가 정확히 반환되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  회전축 프로퍼티 테스트 - ObjectBRotationAxis 가 정확히 반환되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ObjectBRotationAxis_AfterInitialization_ReturnsCorrectAxis()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
+        yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // 몇 프레임 대기하여 Update 실행
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Vector3 axis = _jointComponent.ObjectBRotationAxis;
+        // Assert
+        Vector3 axis = _jointComponent.ObjectBRotationAxis;
         Assert.AreEqual(1f, axis.x, Tolerance);
         Assert.AreEqual(0f, axis.y, Tolerance);
         Assert.AreEqual(0f, axis.z, Tolerance);
     }
 
-    /**
-     * @brief  Y축 회전축 테스트 - Y축 회전축이 정확히 설정되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  Y축 회전축 테스트 - Y축 회전축이 정확히 설정되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ObjectBRotationAxis_YAxis_ReturnsYAxis()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.up);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.up);
         yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert
-        Vector3 axis = _jointComponent.ObjectBRotationAxis;
+        // Assert
+        Vector3 axis = _jointComponent.ObjectBRotationAxis;
         Assert.AreEqual(0f, axis.x, Tolerance);
         Assert.AreEqual(1f, axis.y, Tolerance);
         Assert.AreEqual(0f, axis.z, Tolerance);
     }
 
-    #endregion
+    #endregion
 
-    #region 회전 클램프 테스트
+    #region 회전 클램프 테스트
 
-    /**
-     * @brief  범위 내 회전 테스트 - 범위 내 회전 시 클램프가 적용되지 않는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  범위 내 회전 테스트 - 범위 내 회전 시 클램프가 적용되지 않는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator Rotation_WithinRange_NoClampApplied()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
 
-        // Act - 범위 내 회전 적용
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Quaternion targetRot = Quaternion.Euler(45f, 0, 90f);
-        rb.MoveRotation(targetRot);
+        // Act - 범위 내 회전 적용 (Transform 직접 제어)
+        _objectB.transform.rotation = Quaternion.Euler(45f, 0, 90f);
 
-        yield return new WaitForFixedUpdate();
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 회전이 유지되어야 함
-        float xAngle = _objectB.transform.rotation.eulerAngles.x;
+        // Assert - 회전이 유지되어야 함
+        float xAngle = _objectB.transform.rotation.eulerAngles.x;
         if (xAngle > 180f) xAngle -= 360f;
         Assert.That(Mathf.Abs(xAngle), Is.LessThanOrEqualTo(90f + Tolerance));
     }
 
-    /**
-     * @brief  최대 각도 초과 회전 테스트 - max 초과 시 클램프가 적용되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  최대 각도 초과 회전 테스트 - max 초과 시 클램프가 적용되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator Rotation_ExceedsMax_ClampApplied()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-
-        // Act - max 초과 회전 적용
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Quaternion targetRot = Quaternion.Euler(120f, 0, 90f);
-        rb.MoveRotation(targetRot);
-
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForSeconds(PhysicsWaitTime * 2);
-
-        // Assert - 클램프되어 90도 이하여야 함
-        Assert.That(_jointComponent.CurrentAngle, Is.LessThanOrEqualTo(90f + Tolerance));
-    }
-
-    /**
-     * @brief  최소 각도 미만 회전 테스트 - min 미만 시 클램프가 적용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Rotation_BelowMin_ClampApplied()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-
-        // Act - min 미만 회전 적용
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Quaternion targetRot = Quaternion.Euler(-120f, 0, 90f);
-        rb.MoveRotation(targetRot);
-
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForSeconds(PhysicsWaitTime * 2);
-
-        // Assert - 클램프되어 -90도 이상이어야 함
-        Assert.That(_jointComponent.CurrentAngle, Is.GreaterThanOrEqualTo(-90f - Tolerance));
-    }
-
-    #endregion
-
-    #region SetAngle 테스트
-
-    /**
-     * @brief  SetAngle 범위 내 테스트 - SetAngle 로 범위 내 각도가 설정되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator SetAngle_WithinRange_SetsAngle()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-
-        // Act
-        _jointComponent.SetAngle(45f);
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Assert.AreEqual(45f, _jointComponent.CurrentAngle, Tolerance);
-    }
-
-    /**
-     * @brief  SetAngle 범위 초과 테스트 - SetAngle 로 범위 초과 각도가 클램프되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator SetAngle_ExceedsRange_ClampedToRange()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-
-        // Act
-        _jointComponent.SetAngle(180f);
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Assert.AreEqual(90f, _jointComponent.CurrentAngle, Tolerance);
-    }
-
-    /**
-     * @brief  SetAngle 음수 테스트 - SetAngle 로 음수 각도가 설정되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator SetAngle_NegativeAngle_SetsNegativeAngle()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-
-        // Act
-        _jointComponent.SetAngle(-60f);
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Assert.AreEqual(-60f, _jointComponent.CurrentAngle, Tolerance);
-    }
-
-    #endregion
-
-    #region Rigidbody Constraints 테스트
-
-    /**
-     * @brief  X축 회전축 Constraints 테스트 - X축 회전만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_XAxisRotation_OnlyXRotationAllowed()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        RigidbodyConstraints expected = RigidbodyConstraints.FreezeAll & ~RigidbodyConstraints.FreezeRotationX;
-
-        // Assert (한 줄로 모든 제약 사항을 완벽히 검증)
-        Assert.AreEqual(expected, rb.constraints, "X축 회전만 허용되고 나머지 모든 축은 고정되어야 합니다.");
-    }
-
-    /**
-     * @brief  Y축 회전축 Constraints 테스트 - Y축 회전만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_YAxisRotation_OnlyYRotationAllowed()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.up);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionX), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionY), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionZ), Is.True);
-    }
-
-    /**
-     * @brief  Z축 회전축 Constraints 테스트 - Z축 회전만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_ZAxisRotation_OnlyZRotationAllowed()
-    {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.forward);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionX), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionY), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionZ), Is.True);
-    }
-
-    #endregion
-
-    #region 중력 제어 테스트
-
-    /**
-     * @brief  구속 전 중력 비활성화 테스트 - 구속 전에는 중력이 비활성화되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Gravity_BeforeConstrained_GravityDisabled()
-    {
-        // Arrange - 일치하지 않는 위치로 설정
-        _objectB.transform.position = new Vector3(0, 10, 0);
+        // Arrange
         SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
 
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.IsFalse(rb.useGravity);
+        // Act - max 초과 회전 적용 (Transform 직접 제어)
+        _objectB.transform.rotation = Quaternion.Euler(120f, 0, 90f);
+
+        yield return new WaitForSeconds(PhysicsWaitTime * 2);
+
+        // Assert - 클램프되어 90도 이하여야 함
+        Assert.That(_jointComponent.CurrentAngle, Is.LessThanOrEqualTo(90f + Tolerance));
     }
 
-    /**
-     * @brief  구속 후 중력 활성화 테스트 - 구속 후에는 중력이 활성화되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Gravity_AfterConstrained_GravityEnabled()
+    /**
+     * @brief  최소 각도 미만 회전 테스트 - min 미만 시 클램프가 적용되는지 검증한다.
+     */
+    [UnityTest]
+    public IEnumerator Rotation_BelowMin_ClampApplied()
     {
-        // Arrange - 일치하는 위치로 설정
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
+
+        // Act - min 미만 회전 적용 (Transform 직접 제어)
+        _objectB.transform.rotation = Quaternion.Euler(-120f, 0, 90f);
+
+        yield return new WaitForSeconds(PhysicsWaitTime * 2);
+
+        // Assert - 클램프되어 -90도 이상이어야 함
+        Assert.That(_jointComponent.CurrentAngle, Is.GreaterThanOrEqualTo(-90f - Tolerance));
+    }
+
+    #endregion
+
+    #region SetAngle 테스트
+
+    /**
+     * @brief  SetAngle 범위 내 테스트 - SetAngle 로 범위 내 각도가 설정되는지 검증한다.
+     */
+    [UnityTest]
+    public IEnumerator SetAngle_WithinRange_SetsAngle()
+    {
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
+        yield return null;
+
+        // Act
+        _jointComponent.SetAngle(45f);
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.IsTrue(rb.useGravity);
+        // Assert
+        Assert.AreEqual(45f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    #endregion
+    /**
+     * @brief  SetAngle 최대 초과 테스트 - max 초과 시 클램프되는지 검증한다.
+     */
+    [UnityTest]
+    public IEnumerator SetAngle_ExceedsRange_ClampedToRange()
+    {
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
+        yield return null;
 
-    #region 복합 시나리오 테스트
+        // Act
+        _jointComponent.SetAngle(120f);
+        yield return new WaitForSeconds(PhysicsWaitTime);
 
-    /**
-     * @brief  연속 회전 입력 테스트 - 여러 번의 회전 입력이 정상 처리되는지 검증한다.
-     */
-    [UnityTest]
+        // Assert
+        Assert.AreEqual(90f, _jointComponent.CurrentAngle, Tolerance);
+    }
+
+    /**
+     * @brief  SetAngle 음수 테스트 - 음수 각도가 정상 설정되는지 검증한다.
+     */
+    [UnityTest]
+    public IEnumerator SetAngle_NegativeAngle_SetsNegativeAngle()
+    {
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
+        yield return null;
+
+        // Act
+        _jointComponent.SetAngle(-45f);
+        yield return new WaitForSeconds(PhysicsWaitTime);
+
+        // Assert
+        Assert.AreEqual(-45f, _jointComponent.CurrentAngle, Tolerance);
+    }
+
+    #endregion
+
+    #region 복합 시나리오 테스트
+
+    /**
+     * @brief  연속 회전 입력 테스트 - 여러 번의 회전 입력이 정상 처리되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_ContinuousRotationInput_HandledCorrectly()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
 
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        // Act - 여러 번 회전 입력
-        for (int i = 0; i < 5; i++)
+        // Act - 여러 번 회전 입력 (Transform 직접 제어)
+        for (int i = 0; i < 5; i++)
         {
-            Quaternion currentRot = rb.rotation;
+            Quaternion currentRot = _objectB.transform.rotation;
             Quaternion delta = Quaternion.AngleAxis(10f, Vector3.right);
-            rb.MoveRotation(delta * currentRot);
+            _objectB.transform.rotation = delta * currentRot;
             yield return new WaitForFixedUpdate();
         }
 
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 총 50도 회전 시도했으나 90도 이하로 클램프
-        Assert.That(_jointComponent.CurrentAngle, Is.LessThanOrEqualTo(90f + Tolerance));
+        // Assert - 총 50도 회전 시도했으나 90도 이하로 클램프
+        Assert.That(_jointComponent.CurrentAngle, Is.LessThanOrEqualTo(90f + Tolerance));
     }
 
-    /**
-     * @brief  빠른 회전 변경 테스트 - 빠르게 방향이 바뀔 때도 안정적인지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  빠른 회전 변경 테스트 - 빠르게 방향이 바뀔 때도 안정적인지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_RapidDirectionChange_RemainsStable()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
 
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        // Act - 빠르게 방향 변경
-        float[] angles = { 30f, -30f, 45f, -45f, 60f, -60f };
+        // Act - 빠르게 방향 변경 (Transform 직접 제어)
+        float[] angles = { 30f, -30f, 45f, -45f, 60f, -60f };
         foreach (float angle in angles)
         {
-            Quaternion targetRot = Quaternion.Euler(angle, 0, 90f);
-            rb.MoveRotation(targetRot);
+            _objectB.transform.rotation = Quaternion.Euler(angle, 0, 90f);
             yield return new WaitForFixedUpdate();
         }
 
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 범위 내에 있어야 함
-        Assert.That(_jointComponent.CurrentAngle, Is.InRange(-90f - Tolerance, 90f + Tolerance));
+        // Assert - 범위 내에 있어야 함
+        Assert.That(_jointComponent.CurrentAngle, Is.InRange(-90f - Tolerance, 90f + Tolerance));
     }
 
-    /**
-     * @brief  비대칭 범위 테스트 - 비대칭 min/max 에서도 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  비대칭 범위 테스트 - 비대칭 min/max 에서도 정상 작동하는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_AsymmetricRange_WorksCorrectly()
     {
-        // Arrange
-        SetupJointComponent(-30f, 150f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-30f, 150f, Vector3.right);
         yield return null;
 
-        // Act - 양쪽 경계 테스트
-        _jointComponent.SetAngle(-50f);  // min 미만
-        yield return new WaitForSeconds(PhysicsWaitTime);
+        // Act - 양쪽 경계 테스트
+        _jointComponent.SetAngle(-50f);  // min 미만
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(-30f, _jointComponent.CurrentAngle, Tolerance);
 
-        _jointComponent.SetAngle(200f);  // max 초과
-        yield return new WaitForSeconds(PhysicsWaitTime);
+        _jointComponent.SetAngle(200f);  // max 초과
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(150f, _jointComponent.CurrentAngle, Tolerance);
 
-        _jointComponent.SetAngle(60f);  // 범위 내
-        yield return new WaitForSeconds(PhysicsWaitTime);
+        _jointComponent.SetAngle(60f);  // 범위 내
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(60f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    /**
-     * @brief  좁은 범위 테스트 - 매우 좁은 범위에서도 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  좁은 범위 테스트 - 매우 좁은 범위에서도 정상 작동하는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_NarrowRange_WorksCorrectly()
     {
-        // Arrange
-        SetupJointComponent(-5f, 5f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-5f, 5f, Vector3.right);
         yield return null;
 
-        // Act & Assert
-        _jointComponent.SetAngle(3f);
+        // Act & Assert
+        _jointComponent.SetAngle(3f);
         yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(3f, _jointComponent.CurrentAngle, Tolerance);
 
-        _jointComponent.SetAngle(10f);  // 초과
-        yield return new WaitForSeconds(PhysicsWaitTime);
+        _jointComponent.SetAngle(10f);  // 초과
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(5f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    /**
-     * @brief  넓은 범위 테스트 - 매우 넓은 범위에서도 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  넓은 범위 테스트 - 매우 넓은 범위에서도 정상 작동하는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_WideRange_WorksCorrectly()
     {
-        // Arrange
-        SetupJointComponent(-180f, 180f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-180f, 180f, Vector3.right);
         yield return null;
 
-        // Act & Assert
-        _jointComponent.SetAngle(170f);
+        // Act & Assert
+        _jointComponent.SetAngle(170f);
         yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(170f, _jointComponent.CurrentAngle, Tolerance);
 
@@ -495,105 +393,95 @@ public class RevoluteJointComponentPlayModeTest
         Assert.AreEqual(-170f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    /**
-     * @brief  오브젝트 이동 후 회전 테스트 - 위치 변경 후에도 회전이 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  오브젝트 이동 후 회전 테스트 - 위치 변경 후에도 회전이 정상 작동하는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_AfterPositionChange_RotationStillWorks()
     {
-        // Arrange
-        SetupJointComponent(-90f, 90f, Vector3.right);
+        // Arrange
+        SetupJointComponent(-90f, 90f, Vector3.right);
         yield return null;
 
-        // Act - 위치 변경
-        _objectA.transform.position = new Vector3(5, 5, 5);
+        // Act - 위치 변경 (Transform 직접 제어)
+        _objectA.transform.position = new Vector3(5, 5, 5);
         _objectB.transform.position = new Vector3(5, 5, 5);
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // 회전 설정
-        _jointComponent.SetAngle(45f);
+        // 회전 설정
+        _jointComponent.SetAngle(45f);
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert
-        Assert.AreEqual(45f, _jointComponent.CurrentAngle, Tolerance);
+        // Assert
+        Assert.AreEqual(45f, _jointComponent.CurrentAngle, Tolerance);
     }
 
-    /**
-     * @brief  대각선 축 회전 테스트 - 대각선 축에서도 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  대각선 축 회전 테스트 - 대각선 축에서도 정상 작동하는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ComplexScenario_DiagonalAxis_WorksCorrectly()
     {
-        // Arrange
-        Vector3 diagonalAxis = new Vector3(1, 1, 0).normalized;
+        // Arrange
+        Vector3 diagonalAxis = new Vector3(1, 1, 0).normalized;
         SetupJointComponent(-90f, 90f, diagonalAxis);
         yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 축이 설정되었는지 확인
-        Vector3 axis = _jointComponent.ObjectBRotationAxis;
+        // Assert - 축이 설정되었는지 확인
+        Vector3 axis = _jointComponent.ObjectBRotationAxis;
         Assert.That(axis.magnitude, Is.EqualTo(1f).Within(Tolerance));
     }
 
-    #endregion
+    #endregion
 
-    #region 에러 처리 테스트
+    #region 에러 처리 테스트
 
-    /**
-     * @brief  오브젝트 A 미연결 테스트 - 오브젝트 A 가 없을 때 에러 없이 처리되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  오브젝트 A 미연결 테스트 - 오브젝트 A 가 없을 때 에러 없이 처리되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ErrorHandling_MissingObjectA_HandledGracefully()
     {
-        // 오브젝트 비활성화 (AddComponent 시 Awake 호출 방지)
         _managerObject.SetActive(false);
 
-        // 예상되는 로그 등록 (이 로그가 나와야 테스트 통과)
         UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "RevoluteJointComponent: 필수 오브젝트(A 또는 B)가 할당되지 않았습니다.");
 
-        // Arrange
-        _jointComponent = _managerObject.AddComponent<RevoluteJointComponent>();
+        _jointComponent = _managerObject.AddComponent<RevoluteJointComponent>();
 
         var baseType = typeof(JointComponent);
         baseType.GetField("_objectB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
           .SetValue(_jointComponent, _objectB.transform);
-        // _objectA 는 설정하지 않음
 
-        _managerObject.SetActive(true); // 활성화하여 Awake 실행
-        yield return null;
+        _managerObject.SetActive(true);
+        yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 예외 없이 실행되어야 함
-        Assert.Pass("No exception thrown with missing ObjectA");
+        Assert.Pass("No exception thrown with missing ObjectA");
     }
 
-    /**
-     * @brief  오브젝트 B 미연결 테스트 - 오브젝트 B 가 없을 때 에러 없이 처리되는지 검증한다.
-     */
-    [UnityTest]
+    /**
+     * @brief  오브젝트 B 미연결 테스트 - 오브젝트 B 가 없을 때 에러 없이 처리되는지 검증한다.
+     */
+    [UnityTest]
     public IEnumerator ErrorHandling_MissingObjectB_HandledGracefully()
     {
-        // 오브젝트 비활성화 (AddComponent 시 Awake 호출 방지)
         _managerObject.SetActive(false);
 
-        // 예상되는 로그 등록 (이 로그가 나와야 테스트 통과)
         UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "RevoluteJointComponent: 필수 오브젝트(A 또는 B)가 할당되지 않았습니다.");
 
-        // Arrange
-        _jointComponent = _managerObject.AddComponent<RevoluteJointComponent>();
+        _jointComponent = _managerObject.AddComponent<RevoluteJointComponent>();
 
         var baseType = typeof(JointComponent);
         baseType.GetField("_objectA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
           .SetValue(_jointComponent, _objectA.transform);
-        // _objectB 는 설정하지 않음
 
-        _managerObject.SetActive(true); // 활성화하여 Awake 실행
-        yield return null;
+        _managerObject.SetActive(true);
+        yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 예외 없이 실행되어야 함
-        Assert.Pass("No exception thrown with missing ObjectB");
+        Assert.Pass("No exception thrown with missing ObjectB");
     }
 
-    #endregion
+    #endregion
 }

--- a/unity/Assets/Tests/SliderJointComponentPlayModeTest.cs
+++ b/unity/Assets/Tests/SliderJointComponentPlayModeTest.cs
@@ -1,10 +1,14 @@
 // ============================================================
 // 파일명  : SliderJointComponentPlayModeTest.cs
 // 역할    : SliderJointComponent 클래스의 PlayMode 통합 테스트
-//           실제 씬 환경에서 Rigidbody, 물리 연산, 위치 클램프를 검증한다.
+//           실제 씬 환경에서 Transform 직접 제어, 위치 클램프를 검증한다.
 // 작성자  : 이현화
 // 작성일  : 2026-04-01
-// 수정이력: 
+// 수정이력: 2026-04-22 - Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링
+//                        (Gravity 테스트 제거, Constraints 테스트 제거)
+//                      - SetupJointComponent() 에서 Rigidbody 생성 코드 제거
+//                      - 이동 입력 방식을 Transform.position 직접 제어로 변경
+//                      - Line, Plane 점 좌표 Reflection 설정 추가
 // ============================================================
 
 using System.Collections;
@@ -31,17 +35,13 @@ public class SliderJointComponentPlayModeTest
     [SetUp]
     public void SetUp()
     {
-        // 오브젝트 A 생성 (기준, Kinematic)
+        // 오브젝트 A 생성 (기준)
         _objectA = new GameObject("ObjectA");
         _objectA.transform.position = Vector3.zero;
-        Rigidbody rbA = _objectA.AddComponent<Rigidbody>();
-        rbA.isKinematic = true;
 
         // 오브젝트 B 생성 (이동 대상)
         _objectB = new GameObject("ObjectB");
         _objectB.transform.position = Vector3.zero;
-        Rigidbody rbB = _objectB.AddComponent<Rigidbody>();
-        rbB.useGravity = false;
 
         // SliderJointComponent 를 별도 오브젝트에 추가
         _managerObject = new GameObject("JointManager");
@@ -60,17 +60,16 @@ public class SliderJointComponentPlayModeTest
 
     /**
      * @brief  SliderJointComponent 를 설정하고 초기화한다.
+     *         이동축 Line 과 기준 Plane 을 moveDirection 방향으로 생성하여 설정한다.
      * @param  minPosition     최소 이동 범위
      * @param  maxPosition     최대 이동 범위
      * @param  moveDirection   이동 방향 (월드 기준)
      */
     private void SetupJointComponent(float minPosition, float maxPosition, Vector3 moveDirection)
     {
-        // 매니저 오브젝트 비활성화 (Awake 호출 방지)
         _managerObject.SetActive(false);
         _jointComponent = _managerObject.AddComponent<SliderJointComponent>();
 
-        // Reflection 으로 private SerializeField 설정
         var type = typeof(SliderJointComponent);
         var baseType = typeof(JointComponent);
 
@@ -86,7 +85,38 @@ public class SliderJointComponentPlayModeTest
         type.GetField("_moveDirection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
             .SetValue(_jointComponent, moveDirection);
 
-        // 이제 활성화 (이때 필드가 채워진 상태로 Awake -> InitializeJoint 가 정상 실행됨)
+        // 이동축 Line 점 좌표 설정 (moveDirection 방향으로 lineA, lineB 생성)
+        Vector3 linePointA = Vector3.zero;
+        Vector3 linePointB = moveDirection.sqrMagnitude > 0 ? moveDirection.normalized : Vector3.right;
+
+        type.GetField("_lineAPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, linePointA);
+        type.GetField("_lineAPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, linePointB);
+        type.GetField("_lineBPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, linePointA);
+        type.GetField("_lineBPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, linePointB);
+
+        // 기준 Plane 점 좌표 설정 (moveDirection 과 수직인 평면 생성)
+        Vector3 perpA = Vector3.Cross(linePointB, Vector3.up).sqrMagnitude > 0
+            ? Vector3.Cross(linePointB, Vector3.up).normalized
+            : Vector3.Cross(linePointB, Vector3.right).normalized;
+        Vector3 perpB = Vector3.Cross(linePointB, perpA).normalized;
+
+        type.GetField("_planeAPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, Vector3.zero);
+        type.GetField("_planeAPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, perpA);
+        type.GetField("_planeAPointC", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, perpB);
+        type.GetField("_planeBPointA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, Vector3.zero);
+        type.GetField("_planeBPointB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, perpA);
+        type.GetField("_planeBPointC", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .SetValue(_jointComponent, perpB);
+
         _managerObject.SetActive(true);
     }
 
@@ -102,7 +132,7 @@ public class SliderJointComponentPlayModeTest
     {
         // Arrange & Act
         SetupJointComponent(0f, 100f, Vector3.right);
-        yield return null;  // Awake 실행 대기
+        yield return null;
 
         // Assert
         Assert.IsNotNull(_jointComponent);
@@ -118,11 +148,9 @@ public class SliderJointComponentPlayModeTest
         // Arrange
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
-
-        // 몇 프레임 대기하여 Update 실행
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - CurrentPosition 이 정상적으로 반환되면 초기화 성공
+        // Assert
         Assert.AreEqual(0f, _jointComponent.CurrentPosition, Tolerance);
     }
 
@@ -170,11 +198,9 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        // Act - 범위 내 위치로 이동
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        rb.MovePosition(new Vector3(50f, 0f, 0f));
+        // Act - 범위 내 위치로 이동 (Transform 직접 제어)
+        _objectB.transform.position = new Vector3(50f, 0f, 0f);
 
-        yield return new WaitForFixedUpdate();
         yield return new WaitForSeconds(PhysicsWaitTime);
 
         // Assert - 위치가 유지되어야 함
@@ -191,11 +217,9 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        // Act - max 초과 위치로 이동
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        rb.MovePosition(new Vector3(150f, 0f, 0f));
+        // Act - max 초과 위치로 이동 (Transform 직접 제어)
+        _objectB.transform.position = new Vector3(150f, 0f, 0f);
 
-        yield return new WaitForFixedUpdate();
         yield return new WaitForSeconds(PhysicsWaitTime * 2);
 
         // Assert - 클램프되어 100 이하여야 함
@@ -212,57 +236,13 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        // Act - min 미만 위치로 이동
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        rb.MovePosition(new Vector3(-50f, 0f, 0f));
+        // Act - min 미만 위치로 이동 (Transform 직접 제어)
+        _objectB.transform.position = new Vector3(-50f, 0f, 0f);
 
-        yield return new WaitForFixedUpdate();
         yield return new WaitForSeconds(PhysicsWaitTime * 2);
 
         // Assert - 클램프되어 0 이상이어야 함
         Assert.That(_jointComponent.CurrentPosition, Is.GreaterThanOrEqualTo(0f - Tolerance));
-    }
-
-    /**
-     * @brief  Y축 이동 시 클램프 테스트 - Y축 방향 이동이 정상 클램프되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Movement_YAxis_ClampApplied()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.up);
-        yield return null;
-
-        // Act - Y축으로 max 초과 이동
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        rb.MovePosition(new Vector3(0f, 150f, 0f));
-
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForSeconds(PhysicsWaitTime * 2);
-
-        // Assert
-        Assert.That(_jointComponent.CurrentPosition, Is.LessThanOrEqualTo(100f + Tolerance));
-    }
-
-    /**
-     * @brief  Z축 이동 시 클램프 테스트 - Z축 방향 이동이 정상 클램프되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Movement_ZAxis_ClampApplied()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.forward);
-        yield return null;
-
-        // Act - Z축으로 max 초과 이동
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        rb.MovePosition(new Vector3(0f, 0f, 150f));
-
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForSeconds(PhysicsWaitTime * 2);
-
-        // Assert
-        Assert.That(_jointComponent.CurrentPosition, Is.LessThanOrEqualTo(100f + Tolerance));
     }
 
     #endregion
@@ -281,18 +261,17 @@ public class SliderJointComponentPlayModeTest
 
         // Act
         _jointComponent.SetPosition(50f);
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForEndOfFrame(); // 트랜스폼 반영 대기
+        yield return new WaitForSeconds(PhysicsWaitTime);
 
         // Assert
         Assert.AreEqual(50f, _jointComponent.CurrentPosition, Tolerance);
     }
 
     /**
-     * @brief  SetPosition 범위 초과 테스트 - SetPosition 으로 범위 초과 위치가 클램프되는지 검증한다.
+     * @brief  SetPosition 최대 초과 테스트 - max 초과 시 클램프되는지 검증한다.
      */
     [UnityTest]
-    public IEnumerator SetPosition_ExceedsRange_ClampedToRange()
+    public IEnumerator SetPosition_ExceedsMax_ClampedToMax()
     {
         // Arrange
         SetupJointComponent(0f, 100f, Vector3.right);
@@ -300,18 +279,17 @@ public class SliderJointComponentPlayModeTest
 
         // Act
         _jointComponent.SetPosition(150f);
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForEndOfFrame();
+        yield return new WaitForSeconds(PhysicsWaitTime);
 
         // Assert
         Assert.AreEqual(100f, _jointComponent.CurrentPosition, Tolerance);
     }
 
     /**
-     * @brief  SetPosition 음수 테스트 - SetPosition 으로 음수 위치가 클램프되는지 검증한다.
+     * @brief  SetPosition 최소 미만 테스트 - min 미만 시 클램프되는지 검증한다.
      */
     [UnityTest]
-    public IEnumerator SetPosition_NegativePosition_ClampedToMin()
+    public IEnumerator SetPosition_BelowMin_ClampedToMin()
     {
         // Arrange
         SetupJointComponent(0f, 100f, Vector3.right);
@@ -323,145 +301,6 @@ public class SliderJointComponentPlayModeTest
 
         // Assert
         Assert.AreEqual(0f, _jointComponent.CurrentPosition, Tolerance);
-    }
-
-    /**
-     * @brief  SetPosition 음수 범위 테스트 - 음수 범위에서 정상 작동하는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator SetPosition_NegativeRange_WorksCorrectly()
-    {
-        // Arrange
-        SetupJointComponent(-100f, -50f, Vector3.right);
-        yield return null;
-
-        // Act
-        _jointComponent.SetPosition(-75f);
-        yield return new WaitForFixedUpdate();
-        yield return new WaitForEndOfFrame();
-
-        // Assert
-        Assert.AreEqual(-75f, _jointComponent.CurrentPosition, Tolerance);
-    }
-
-    #endregion
-
-    #region Rigidbody Constraints 테스트
-
-    /**
-     * @brief  X축 이동 방향 Constraints 테스트 - X축 이동만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_XAxisMovement_OnlyXMovementAllowed()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.right);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        // 위치 Y, Z 가 프리즈되어 있어야 함
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionY), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionZ), Is.True);
-
-        // 위치 X 는 프리즈되지 않아야 함
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionX), Is.False);
-    }
-
-    /**
-     * @brief  Y축 이동 방향 Constraints 테스트 - Y축 이동만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_YAxisMovement_OnlyYMovementAllowed()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.up);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionX), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionZ), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionY), Is.False);
-    }
-
-    /**
-     * @brief  Z축 이동 방향 Constraints 테스트 - Z축 이동만 허용되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_ZAxisMovement_OnlyZMovementAllowed()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.forward);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionX), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionY), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezePositionZ), Is.False);
-    }
-
-    /**
-     * @brief  회전 Constraints 테스트 - 모든 회전이 프리즈되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Constraints_AllRotationFrozen()
-    {
-        // Arrange
-        SetupJointComponent(0f, 100f, Vector3.right);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezeRotationX), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezeRotationY), Is.True);
-        Assert.That(rb.constraints.HasFlag(RigidbodyConstraints.FreezeRotationZ), Is.True);
-    }
-
-    #endregion
-
-    #region 중력 제어 테스트
-
-    /**
-     * @brief  구속 전 중력 비활성화 테스트 - 구속 전에는 중력이 비활성화되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Gravity_BeforeConstrained_GravityDisabled()
-    {
-        // Arrange - 일치하지 않는 위치로 설정
-        _objectB.transform.position = new Vector3(0, 10, 0);
-        _objectB.transform.rotation = Quaternion.Euler(45, 45, 45);  // 회전도 다르게
-        SetupJointComponent(0f, 100f, Vector3.right);
-        yield return null;
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.IsFalse(rb.useGravity);
-    }
-
-    /**
-     * @brief  구속 후 중력 활성화 테스트 - 구속 후에는 중력이 활성화되는지 검증한다.
-     */
-    [UnityTest]
-    public IEnumerator Gravity_AfterConstrained_GravityEnabled()
-    {
-        // Arrange - 일치하는 위치로 설정
-        SetupJointComponent(0f, 100f, Vector3.right);
-        yield return null;
-        yield return new WaitForSeconds(PhysicsWaitTime);
-
-        // Assert
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-        Assert.IsTrue(rb.useGravity);
     }
 
     #endregion
@@ -478,13 +317,11 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        // Act - 여러 번 이동 입력
+        // Act - 여러 번 이동 입력 (Transform 직접 제어)
         for (int i = 0; i < 5; i++)
         {
-            Vector3 currentPos = rb.position;
-            rb.MovePosition(currentPos + Vector3.right * 10f);
+            Vector3 currentPos = _objectB.transform.position;
+            _objectB.transform.position = currentPos + Vector3.right * 10f;
             yield return new WaitForFixedUpdate();
         }
 
@@ -504,13 +341,11 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        Rigidbody rb = _objectB.GetComponent<Rigidbody>();
-
-        // Act - 빠르게 위치 변경
+        // Act - 빠르게 위치 변경 (Transform 직접 제어)
         float[] positions = { 30f, -10f, 50f, 120f, 80f, -20f };
         foreach (float pos in positions)
         {
-            rb.MovePosition(new Vector3(pos, 0f, 0f));
+            _objectB.transform.position = new Vector3(pos, 0f, 0f);
             yield return new WaitForFixedUpdate();
         }
 
@@ -532,18 +367,15 @@ public class SliderJointComponentPlayModeTest
 
         // Act - 양쪽 경계 테스트
         _jointComponent.SetPosition(-50f);  // min 미만
-        yield return new WaitForFixedUpdate(); // 물리 연산 대기
-        yield return new WaitForEndOfFrame();  // 트랜스폼 반영 대기
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(-30f, _jointComponent.CurrentPosition, Tolerance);
 
         _jointComponent.SetPosition(200f);  // max 초과
-        yield return new WaitForFixedUpdate(); // 물리 연산 대기
-        yield return new WaitForEndOfFrame();  // 트랜스폼 반영 대기
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(150f, _jointComponent.CurrentPosition, Tolerance);
 
         _jointComponent.SetPosition(60f);  // 범위 내
-        yield return new WaitForFixedUpdate(); // 물리 연산 대기
-        yield return new WaitForEndOfFrame();  // 트랜스폼 반영 대기
+        yield return new WaitForSeconds(PhysicsWaitTime);
         Assert.AreEqual(60f, _jointComponent.CurrentPosition, Tolerance);
     }
 
@@ -601,7 +433,7 @@ public class SliderJointComponentPlayModeTest
         SetupJointComponent(0f, 100f, Vector3.right);
         yield return null;
 
-        // Act - 오브젝트 A 위치 변경
+        // Act - 오브젝트 A 위치 변경 (Transform 직접 제어)
         _objectA.transform.position = new Vector3(50f, 50f, 50f);
         _objectB.transform.position = new Vector3(50f, 50f, 50f);
         yield return new WaitForSeconds(PhysicsWaitTime);
@@ -640,26 +472,21 @@ public class SliderJointComponentPlayModeTest
     [UnityTest]
     public IEnumerator ErrorHandling_MissingObjectA_HandledGracefully()
     {
-        // 오브젝트 비활성화 (AddComponent 시 Awake 호출 방지)
         _managerObject.SetActive(false);
 
-        // 에러 로그 예상 등록 (SliderJointComponent 이름 확인)
         UnityEngine.TestTools.LogAssert.Expect(LogType.Error,
             new System.Text.RegularExpressions.Regex("SliderJointComponent: 필수 오브젝트.*"));
 
-        // Arrange
         _jointComponent = _managerObject.AddComponent<SliderJointComponent>();
 
         var baseType = typeof(JointComponent);
         baseType.GetField("_objectB", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
             .SetValue(_jointComponent, _objectB.transform);
-        // _objectA 는 설정하지 않음
 
-        _managerObject.SetActive(true); // 활성화하여 Awake 실행
+        _managerObject.SetActive(true);
         yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 예외 없이 실행되어야 함
         Assert.Pass("No exception thrown with missing ObjectA");
     }
 
@@ -669,26 +496,21 @@ public class SliderJointComponentPlayModeTest
     [UnityTest]
     public IEnumerator ErrorHandling_MissingObjectB_HandledGracefully()
     {
-        // 오브젝트 비활성화 (AddComponent 시 Awake 호출 방지)
         _managerObject.SetActive(false);
 
-        // 에러 로그 예상 등록 (SliderJointComponent 이름 확인)
         UnityEngine.TestTools.LogAssert.Expect(LogType.Error,
             new System.Text.RegularExpressions.Regex("SliderJointComponent: 필수 오브젝트.*"));
 
-        // Arrange
         _jointComponent = _managerObject.AddComponent<SliderJointComponent>();
 
         var baseType = typeof(JointComponent);
         baseType.GetField("_objectA", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
             .SetValue(_jointComponent, _objectA.transform);
-        // _objectB 는 설정하지 않음
 
-        _managerObject.SetActive(true); // 활성화하여 Awake 실행
+        _managerObject.SetActive(true);
         yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 예외 없이 실행되어야 함
         Assert.Pass("No exception thrown with missing ObjectB");
     }
 
@@ -699,11 +521,11 @@ public class SliderJointComponentPlayModeTest
     public IEnumerator ErrorHandling_ZeroMoveDirection_HandledGracefully()
     {
         // Arrange
-        SetupJointComponent(0f, 100f, Vector3.zero);  // 영벡터
+        SetupJointComponent(0f, 100f, Vector3.zero);
         yield return null;
         yield return new WaitForSeconds(PhysicsWaitTime);
 
-        // Assert - 예외 없이 실행되어야 함 (정규화 시 0 벡터 처리)
+        // Assert - 예외 없이 실행되어야 함
         Assert.Pass("No exception thrown with zero move direction");
     }
 


### PR DESCRIPTION
## 개요
 
Issue #21 — 셔틀 Y축 리프트 동작 구현 및 전체 리팩토링
 
셔틀의 X축 바퀴(xwheel1-4) 자전 및 Z축 이동, Y축 바퀴(ywheel1-4) 자전 및 X축 이동, 스퍼기어(spurgear1) 회전에 따른 수직 슬라이더(vslider1) Y축 승강을 구현했습니다.  
래크 앤 피니언 구동 시 슬라이더와 셔틀의 이동 주체를 전환하는 `DirectionSwitchController` 를 신규 구현했으며, 디지털 트윈 특성에 맞게 Rigidbody 를 전면 제거하고 Transform 직접 제어 방식으로 리팩토링했습니다.
 
---
 
## 배경 — Rigidbody 제거 리팩토링
 
### 이전 구조의 문제
 
기존 코드는 `Rigidbody` 를 사용하여 물리 엔진 기반으로 오브젝트를 제어했습니다.
 
```
Rigidbody.MoveRotation() → 회전 적용
Rigidbody.MovePosition() → 위치 적용
```
 
그러나 이 프로젝트는 **디지털 트윈**으로, 실제 장비의 움직임을 시각적으로 재현하는 것이 목적입니다. 물리 엔진(중력, 충돌, 관성 등)이 개입하면 오히려 정확한 재현을 방해하는 문제가 있었습니다.
 
### 문제점 정리
 
| 문제 | 원인 |
|---|---|
| 물리 연산 딜레이 | `FixedUpdate` 주기에 종속되어 즉각 반응 불가 |
| 불필요한 중력/충돌 처리 | 디지털 트윈에서 물리 시뮬레이션 불필요 |
| 코드 복잡도 증가 | `Rigidbody` 초기화, Freeze 설정 등 불필요한 코드 |
| 테스트 어려움 | `FixedUpdate` 타이밍에 의존하는 테스트 불안정 |
 
### 해결 방향
 
**Rigidbody 를 전면 제거하고 Transform 직접 제어 방식으로 전환**
 
```
Transform.rotation = ... → 회전 즉시 적용
Transform.position = ... → 위치 즉시 적용
```
 
이를 통해 코드가 단순해지고 MQTT 신호에 즉각 반응하는 구조가 됐습니다.
 
---
 
## 변경 사항
 
### 1. `JointComponent.cs`
 
- `_rigidbodyA`, `_rigidbodyB`, `_freezeConstraint` 필드 제거
- `InitializeRigidbody()`, `GetFreezeConstraintByDirection()` 메서드 제거
- `Update()` 에서 constraints 코드 제거, `OnConstrained()` 호출만 유지
- `ObjectB` 프로퍼티 추가 — `XWheelController` 등 외부에서 오브젝트 B 접근용
```csharp
public Transform ObjectB => _objectB;
```
 
---
 
### 2. `RevoluteJointComponent.cs`
 
- `_rotationAxis` 필드 제거 (미사용, `_lineBPointA/B` 로 대체)
- `_useClamp` 필드 추가 — Inspector 에서 클램프 온오프 선택 가능
```csharp
[SerializeField] private bool _useClamp = true;  // false 면 무한 회전 가능
```
 
**추가 배경**: xwheel1~4 는 무한 회전이 필요한데, 기존 클램프 구조(min/max 고정)로는 360도 이상 회전이 불가능했습니다. `_useClamp = false` 로 설정하면 클램프 없이 무한 회전할 수 있습니다.
 
- `SetAngle()` — `MoveRotation()` → `Transform.rotation` 직접 제어로 변경
- `OnConstrained()` — `_objectBRotationAxis` 매 프레임 갱신 제거 (각도 계산 불안정 문제 수정)
- `_localLineBCenter` 추가 — 셔틀 이동 후에도 올바른 `LineBCenter` 반환을 위해 부모 기준 로컬 좌표로 저장
---
 
### 3. `SliderJointComponent.cs`
 
- `OnConstrained()`, `SetPosition()` — `_initialPosition` 기준으로 통일
**수정 배경**: 기존에는 `OnConstrained()` 는 `_objectA.position` 기준, `SetPosition()` 은 `_initialPosition` 기준으로 서로 달라 누적 오차가 발생했습니다. 둘 다 `_initialPosition` 기준으로 통일하여 해결했습니다.
 
- `MovePosition()` → `Transform.position` 직접 제어로 변경
- `_localInitialPosition` 추가 — 셔틀 X/Z 이동 후 슬라이더 순간이동 문제 수정을 위해 부모 기준 로컬 좌표로 저장
---
 
### 4. `RevoluteFreezeTestManager.cs`
 
- `_rigidbodyB` 제거, `FixedUpdate()` 삭제
- `Update()` 에서 Transform 직접 제어로 즉시 적용
- `LineBCenter` 기반 위치 보정 추가 (`_centerPoint`, `_centerOffset`)
- `OnClampedCallback` 등록 — 클램프 후 offset, rotation 동기화
---
 
### 5. `SliderFreezeTestManager.cs`
 
- `_rigidbodyB`, `_pendingPosition`, `_hasPending` 제거, `FixedUpdate()` 삭제
- `Update()` 에서 `Transform.position` 직접 제어
---
 
### 6. `ConstraintAssemblyWindow.cs` (수정)
 
> ⚠️ 본 파일은 이번 PR 범위에 포함되지 않아야 하나, 작업 중 실수로 수정 및 커밋되었습니다.  
> 다음 PR 부터는 범위 외 파일 수정에 주의하겠습니다.
 
- `CreateJoint()` — `RevoluteJoint` 생성 시 `_lineAPointA/B`, `_lineBPointA/B` 점 좌표 저장 추가
- `CreateJoint()` — `SliderJoint` 생성 시 Line/Plane 점 좌표 저장 추가
- `SnapRevoluteJoint()` — 스냅 후 lineB 좌표 업데이트 및 lineA 방향 일치 처리 추가
---
 
### 7. `RackAndPinionController.cs` (신규)
 
spurgear1 의 회전각을 읽어 vslider1 의 이동 거리로 변환하는 컨트롤러입니다.
 
- delta 방식으로 순간이동 방지
- 노이즈 필터 적용 — `deltaPosition < 0.0001f` 시 무시
- 순간이동 감지 — `deltaAngleRad > 0.1f` 시 무시
- `OnPositionChanged` 이벤트 추가 — `DirectionSwitchController` 가 구독하여 Phase 에 따라 이동 처리
**신호 흐름**:
```
MQTT → spurgear1 회전 → RackAndPinionController → vslider1 이동 / DirectionSwitchController 에 위임
```
 
---
 
### 8. `XWheelController.cs` (신규)
 
xwheel1~4 를 자전시키고 셔틀을 Z축 방향으로 이동시키는 컨트롤러입니다.
 
- `LineBCenter` 기준 offset 방식으로 자전 구현 (피벗 오프셋 문제 해결)
**신호 흐름**:
```
MQTT → "X초 동안 이동" 신호 → XWheelController → xwheel1~4 자전 + 셔틀 Z축 이동
```
 
---
 
### 9. `YWheelController.cs` (신규)
 
ywheel1~4 를 자전시키고 셔틀을 X축 방향으로 이동시키는 컨트롤러입니다.  
`XWheelController` 와 동일한 구조이며 이동 축만 다릅니다 (`Vector3.forward` → `Vector3.right`).
 
---
 
### 10. `SpurGearController.cs` (신규)
 
spurgear1 을 자전시키는 컨트롤러입니다.
 
- `IsSignal`, `IsForward` 프로퍼티 추가 — `DirectionSwitchController` 에서 방향 분기 및 Phase 전환 감지에 사용
**신호 흐름**:
```
MQTT → "X초 동안 회전" 신호 → SpurGearController → spurgear1 자전
```
 
---
 
### 11. `DirectionSwitchController.cs` (신규)
 
래크 앤 피니언 구동 시 슬라이더와 셔틀의 이동 주체를 전환하는 컨트롤러입니다.
 
#### 동작 원리
 
| 방향 | Phase 1 | 전환 조건 | Phase 2 |
|---|---|---|---|
| 내려가는 방향 (IsForward=true) | SliderMoving — 슬라이더 하강 | ywheel3 Y최저점 ≤ `_targetFloorY` | ShuttleMoving — 셔틀 상승 |
| 올라가는 방향 (IsForward=false) | ShuttleMoving — 셔틀 하강 | xwheel1 Y최저점 ≤ `_targetFloorY` | SliderMoving — 슬라이더 상승 |
 
#### `_targetFloorY` 설정 원리
 
신호 시작 시 xwheel1 과 ywheel3 의 Y최저점 중 더 낮은 값을 저장합니다.
 
- 내려가는 방향: 슬라이더가 아직 내려가지 않았으므로 `xwheel1.Y < ywheel3.Y` → xwheel1.Y 가 기준
- 올라가는 방향: 슬라이더가 이미 내려가 있으므로 `ywheel3.Y < xwheel1.Y` → ywheel3.Y 가 기준
셔틀이 X/Z 이동 후에도 신호 시작 시 재계산되므로 어떤 위치에서도 올바른 기준점을 설정합니다.
 
#### 슬라이더 고정 방식
 
vslider1 은 셔틀의 자식이므로 셔틀 Y 이동 시 함께 이동합니다. ShuttleMoving 진입 시 슬라이더의 셔틀 기준 X/Z 로컬 오프셋과 월드 Y 를 분리 저장하여, 셔틀 Y 이동에도 슬라이더 Y 가 고정되도록 합니다.
 
#### 중복 신호 방어
 
쿨다운 중 신호 재입력은 직전 Phase 전환이 아직 진행 중임을 의미하므로 무시합니다.
 
---
 
## 테스트 변경
 
### EditMode 테스트
 
| 파일 | 변경 내용 |
|---|---|
| `PlaneTest.cs` | `Contains_Point_SmallEpsilonOff_ReturnsFalse` 기준값 수정 (`2e-6f` → `0.02f`, Tolerance 변경에 따라 조정) |
| `LineTest.cs` | `Contains_OffLine_ReturnsFalse` Y 오프셋 `0.001f` → `0.03f` 로 수정 (Tolerance `0.02f` 변경에 따라 허용 범위 밖 값으로 조정) |
 
### PlayMode 테스트
 
| 파일 | 변경 내용 |
|---|---|
| `RevoluteJointComponentPlayModeTest.cs` | Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링, `_rotationAxis` Reflection → Line 점 좌표 방식으로 변경 |
| `SliderJointComponentPlayModeTest.cs` | Rigidbody 제거, Transform 직접 제어 방식으로 리팩토링, Line/Plane 점 좌표 Reflection 설정 추가 |
 
### 테스트 결과
 
신규 스크립트(`DirectionSwitchController`, `SpurGearController`, `YWheelController`)는 추후 MQTT 신호 연동 시 테스트 예정입니다.
 
- EditMode: 232개 전체 Pass ✅
- PlayMode: 38개 전체 Pass ✅
- Console 에러/경고 없음 ✅
---
 
## 완료 조건
 
- [x] 새로운 기능 구현 완료 (XWheelController, YWheelController, SpurGearController, RackAndPinionController, DirectionSwitchController)
- [x] Rigidbody 제거 리팩토링 완료
- [x] 셔틀 X/Z 이동 후 Y축 리프트 정상 동작 확인
- [x] 테스트 수정 및 전체 Pass 확인
- [x] Console 에러/경고 없음
- [x] 코드 주석 및 수정이력 업데이트
---
 
## 관련 이슈
 
closes __#21__